### PR TITLE
Deploy as Frontdoor backend

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
+++ b/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
@@ -18,10 +18,16 @@ jobs:
     env:
       REACT_APP_MQE_URL: ${{ secrets.MQE_URL }}
       REACT_APP_JSLL_APP_ID: ${{ secrets.JSLL_APP_ID }}
+      PUBLIC_URL: ''
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: "Set PUBLIC_URL from branch"
+        if: ${{ endsWith(github.ref, 'develop') }}
+        run: |
+          echo "PUBLIC_URL=/catalog" >> $GITHUB_ENV 
+          echo "setting URL"
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v0.0.1-preview

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "pc-datacatalog",
   "version": "0.1.0",
   "private": true,
   "proxy": "http://localhost:7071/",

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <base href="%PUBLIC_URL%/">
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import AccountSurvey from "./pages/AccountSurvey";
 
 function App() {
   return (
-    <Router>
+    <Router basename={process.env.PUBLIC_URL}>
       <Layout>
         <div>
           <Switch>


### PR DESCRIPTION
Make changes to the GH Action to build the production site at `/catalog`, but continue using deploy previews at root. Set the `PUBLIC_URL` variable in your `.env` locally to mimic this behavior.