### PR TITLE
Ensure EU cookie banner is shown after navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="cookie-banner"></div>
     <div id="root"></div>
   </body>
 </html>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -68,16 +68,11 @@ const Header = () => (
         </HeaderLink>
         <HeaderLink to="/applications">Applications</HeaderLink>
         <HeaderLink to="/docs">Documentation</HeaderLink>
-        <HeaderLink
-          asButton
-          to="/account/request"
-          // style={{ marginLeft: "auto", marginTop: "inherit" }}
-        >
+        <HeaderLink asButton to="/account/request">
           Request access
         </HeaderLink>
       </Stack>
     </nav>
-    <div id="cookie-banner"></div>
   </header>
 );
 

--- a/src/components/Seo.js
+++ b/src/components/Seo.js
@@ -84,6 +84,10 @@ function SEO({ description, lang, meta, title }) {
                     // Track a global object for consent to make it available from the
                     // application React components
                     window.siteConsent = siteConsent;
+                    if (siteConsent?.isConsentRequired) {
+                      // Scroll to top to ensure that the cookie banner is visible
+                      window.scrollTo(0,0);
+                    }
                 }
             });
 


### PR DESCRIPTION
During app-route navigation, the cookie-container element would be
re-rendered and emptied, since the content is managed by an external
library that directly manipulates the DOM. I moved the banner container
outside of the React app, so that it is persisted between re-renders. I
also adjusted the page load behavior to scroll to the top when in a
consent-required zone to ensure the banner is visible when reloading the
page.