### PR TITLE
Better formatting of ItemAssets

### DIFF
--- a/src/components/stac/ItemAssets.js
+++ b/src/components/stac/ItemAssets.js
@@ -6,6 +6,7 @@ import {
 } from "@fluentui/react";
 
 import { renderItemColumn, stacFormatter } from "../../utils/stac";
+import { sortByLookup } from "../../utils";
 
 // The list component does not size columns to fit content. We need to set min
 // and max widths in order to set an initial size. Based on a known set of
@@ -14,6 +15,16 @@ const defaultWidth = 100;
 const columnWidths = {
   title: 150,
   gsd: 30,
+  description: 100,
+};
+
+// Use for consistent ordering
+const columnOrders = {
+  title: 0,
+  roles: 10,
+  type: 20,
+  gsd: 30,
+  "eo:bands": 40,
   description: 100,
 };
 
@@ -36,17 +47,24 @@ const ItemAssets = itemAssets => {
       )
     );
 
+    // Use specified, consistent ordering for columns
+    columnKeys.sort(sortByLookup(columnOrders));
+
     // Create objects with keys matching the column keys above.
     const items = Object.values(ia.properties).map(({ value }) => {
       // Convert arrays to joined strings, unless there is special handling for
       // certain keys defined.
-      const skipFormat = [bandKey];
+      const skipFormat = [bandKey, "description"];
 
       const entries = Object.entries(value).map(([key, val]) => {
         if (typeof va === Array && !skipFormat.includes(key)) {
           return [key, val.join(", ")];
         }
-        return [key, stacFormatter.format(val, key)];
+        const formattedVal = skipFormat.includes(key)
+          ? val
+          : stacFormatter.format(val, key);
+
+        return [key, formattedVal];
       });
 
       // eo:bands are concatanated specially

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -31,6 +31,20 @@ export const sortSpecialByKey = key => {
   };
 };
 
+export const sortByLookup = lookup => {
+  const get = k => lookup[k] ?? 50;
+
+  return (a, b) => {
+    if (get(a) < get(b)) {
+      return -1;
+    }
+    if (get(a) > get(b)) {
+      return 1;
+    }
+    return 0;
+  };
+};
+
 export const buildHubLaunchUrl = ({ repo, filePath, branch }) => {
   const urlRepo = encodeURIComponent(repo);
   const urlBranch = encodeURIComponent(branch);


### PR DESCRIPTION
The STAC formatter outputs html for description, so don't use it. Also,
specify an order for common asset column names so they are consistent
and logical.