### PR TITLE
Remove "Azure" from front page hero and og

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     />
     <meta property="og:type" content="website">
     <meta property="og:title" content="Microsoft Planetary Computer">
-    <meta property="og:description" content="Supporting sustainability decision-making with the power of the Azure cloud">
+    <meta property="og:description" content="Supporting sustainability decision-making with the power of the cloud">
     <meta property="og:image" content="https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/landsat.png">
 
     <meta name="twitter:card" content="summary_large_image">

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -68,7 +68,7 @@ const Home = () => {
               The Planetary Computer is only as strong as the partner community
               that is building applications on it. If you are interested in
               scaling your environmental sustainability work with the power of
-              the Azure cloud,{" "}
+              the cloud,{" "}
               <Link
                 underline
                 href="mailto:planetarycomputer@microsoft.com"
@@ -123,7 +123,7 @@ const Home = () => {
           variant="xxLarge"
           style={{ textAlign: "center", maxWidth: "550px" }}
         >
-          Supporting sustainability decision-making with the power of the Azure
+          Supporting sustainability decision-making with the power of the
           cloud
         </Text>
         <Text


### PR DESCRIPTION
Based on a conversation with @agentmorris and the Science Team, we think it makes sense to remove the word Azure from the frontpage hero text and og descriptor.

It still appears, as it makes sense, in many other places when making specific references to assets and computation location.

PS This is the first PR I make to this stac. I've made a new branch, changes look good on local, and I assume there are no more changes or checks to do before reviewing and then merging this PR to prod.