### PR TITLE
Pin etl dependencies

### DIFF
--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -3,11 +3,12 @@ ipython==7.22.0
 nbconvert==6.0.*
 
 # Sphinx docs rendering
+Jinja2==2.11.3
 myst-parser>=0.13.5
-nbsphinx 
-nbconvert
-nbformat
-numpydoc
+nbsphinx==0.8.3
+nbconvert==6.0.*
+nbformat==5.1.3
+numpydoc==1.1.0
 pyyaml==5.4.1
 requests
-sphinx
+sphinx==3.5.4


### PR DESCRIPTION
After a new release of Sphinx and Jinja2 were picked up, nbformat
commands would fail during build. Pin all dependencies at a working
version and consider upgrading to Sphinx 4 when nb tools are compatible.