### PR TITLE
Ensure hash link fragments work on docs site

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 export default function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
+    if (!hash) window.scrollTo(0, 0);
+  }, [pathname, hash]);
 
   return null;
 }

--- a/src/components/ScrollToTopOnMount.js
+++ b/src/components/ScrollToTopOnMount.js
@@ -1,9 +1,11 @@
 import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
 export function ScrollToTopOnMount() {
+  const { hash } = useLocation();
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
+    if (!hash) window.scrollTo(0, 0);
+  }, [hash]);
 
   return null;
 }

--- a/src/components/docs/DocsHtmlContent.js
+++ b/src/components/docs/DocsHtmlContent.js
@@ -49,6 +49,7 @@ const DocsHtmlContent = ({ className, markupJson, children }) => {
   // Serialize the content back to a string so it can be injected
   const processedMarkup = new XMLSerializer().serializeToString(docsDoc);
 
+  // Handle any internal links as an SPA style route, not a full reload
   const handleClick = e => {
     const anchor = e.target.closest("a.reference.internal");
     if (anchor) {

--- a/src/components/docs/GeneratedInternalToc.js
+++ b/src/components/docs/GeneratedInternalToc.js
@@ -1,6 +1,7 @@
 import { Link } from "@fluentui/react";
 import React, { useEffect, useState } from "react";
 import { HashLink } from "react-router-hash-link";
+import { scrollToHash } from "../../utils";
 
 const getHeadingId = heading => {
   if (heading.id) {
@@ -12,18 +13,6 @@ const getHeadingId = heading => {
     const href = childAnchor.href;
     return href.substring(href.lastIndexOf("#"), href.length);
   }
-};
-
-const scrollTo = elementId => {
-  // Remove the hash
-  const id = elementId.substring(elementId.lastIndexOf("#") + 1);
-
-  return () => {
-    const el = document.getElementById(id);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth" });
-    }
-  };
 };
 
 // nohash: don't use the URL hash, as it may already be in use (ie, tabs).
@@ -45,7 +34,7 @@ const GeneratedInternalToc = ({ nohash = false, html }) => {
     return (
       <li key={hash} className="toctree-l1">
         {nohash ? (
-          <Link onClick={scrollTo(hash)}>{text}</Link>
+          <Link onClick={scrollToHash(hash)}>{text}</Link>
         ) : (
           <HashLink smooth to={hash}>
             {text}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -93,3 +93,15 @@ export const a11yPostProcessDom = dom => {
     el.setAttribute("tabindex", 0);
   });
 };
+
+export const scrollToHash = (elementId, behavior = "smooth") => {
+  // Remove the hash
+  const id = elementId.substring(elementId.lastIndexOf("#") + 1);
+
+  return () => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: behavior });
+    }
+  };
+};


### PR DESCRIPTION
The docs page uses internal anchors for section navigation and updates
the URL. The react-router system scrolls to top when navigating pages,
and overrides the hash link. Suppress that behavior when a hash is
present in the URL.