### PR TITLE
Add jrc-gsw example notebook to codefiles_urls.txt

### DIFF
--- a/etl/config/codefiles_urls.txt
+++ b/etl/config/codefiles_urls.txt
@@ -34,3 +34,4 @@ https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datas
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/io-lulc/io-lulc-example.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/3dep/3dep-seamless-example.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/gap/gap-example.ipynb
+https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/jrc-gsw/jrc-gsw-example.ipynb


### PR DESCRIPTION
I had added the jrc notebook to the dataset configuration, but missed adding it the this file to ensure the HTML page is built during the ETL process.