### PR TITLE
Skip grouping if group is not yet configured.

### DIFF
--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -47,7 +47,7 @@ export const stacTagFilter = (collections, tags) => {
     return collections.reduce((accum, collection) => {
       const groupId = collection["msft:group_id"];
 
-      if (groupId) {
+      if (groupId && groups[groupId]) {
         // Don't add the group again if it's been added
         const filtered = addedGroups.has(groupId)
           ? accum


### PR DESCRIPTION
This PR adds a check to see if a Collection group is configured, and if not, skips the grouping mechanism for those Collections. This will allow the staging site to not break when we've ingested collections requiring a group but before they have been configured.

Hit on this after ingesting the GOES collections, which have an `msft:group_id`, but not yet a configured group. 