### PR TITLE
Reset to include removing query string params

### DIFF
--- a/src/pages/Explore/components/Sidebar/ResetSelectors.tsx
+++ b/src/pages/Explore/components/Sidebar/ResetSelectors.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { FontSizes, Link, Stack } from "@fluentui/react";
 
 import { useExploreDispatch, useExploreSelector } from "../../state/hooks";
-import { resetMosiac } from "pages/Explore/state/mosaicSlice";
+import { resetMosaicState } from "pages/Explore/state/mosaicSlice";
 
 const ResetSelectors = () => {
   const dispatch = useExploreDispatch();
@@ -10,7 +10,7 @@ const ResetSelectors = () => {
   const disabled = !collection;
 
   const handleClick = useCallback(() => {
-    dispatch(resetMosiac());
+    dispatch(resetMosaicState());
   }, [dispatch]);
 
   return (

--- a/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlState.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlState.tsx
@@ -12,8 +12,8 @@ import { IMosaic, IMosaicRenderOption } from "pages/Explore/types";
 import { updateQueryStringParam } from "pages/Explore/utils";
 
 const collectionKey = "d";
-const mosaicKey = "m";
-const renderKey = "r";
+export const mosaicQsKey = "m";
+export const renderQsKey = "r";
 
 interface INamedObject {
   name: string | null;
@@ -57,11 +57,11 @@ const useUrlState = (
 export const useRenderUrlState = (
   renderOptions: IMosaicRenderOption[] | null | undefined
 ) => {
-  useUrlState(renderOptions, "renderOption", renderKey, setRenderOption);
+  useUrlState(renderOptions, "renderOption", renderQsKey, setRenderOption);
 };
 
 export const useMosaicUrlState = (mosaics: IMosaic[] | null | undefined) => {
-  useUrlState(mosaics, "query", mosaicKey, setMosaicQuery);
+  useUrlState(mosaics, "query", mosaicQsKey, setMosaicQuery);
 };
 
 export const useCollectionUrlState = (collections: IStacCollection[] | null) => {

--- a/src/pages/Explore/state/mosaicSlice.ts
+++ b/src/pages/Explore/state/mosaicSlice.ts
@@ -3,8 +3,9 @@ import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
 import { IStacCollection } from "types/stac";
 import { createMosaicQueryHashkey } from "utils/requests";
 import { IMosaic, IMosaicRenderOption } from "../types";
+import { resetMosaicQueryStringState } from "../utils";
 import { DEFAULT_MIN_ZOOM } from "../utils/constants";
-import { ExploreState } from "./store";
+import { AppThunk, ExploreState } from "./store";
 
 export interface MosaicState {
   collection: IStacCollection | null;
@@ -54,6 +55,11 @@ export const setMosaicQuery = createAsyncThunk<string, IMosaic>(
     return hashkey;
   }
 );
+
+export const resetMosaicState = (): AppThunk => dispatch => {
+  resetMosaicQueryStringState();
+  dispatch(resetMosiac());
+};
 
 export const mosaicSlice = createSlice({
   name: "mosaic",

--- a/src/pages/Explore/state/store.ts
+++ b/src/pages/Explore/state/store.ts
@@ -1,4 +1,4 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, ThunkAction, Action } from "@reduxjs/toolkit";
 import mosaicReducer from "./mosaicSlice";
 import mapReducer from "./mapSlice";
 import detailReducer from "./detailSlice";
@@ -13,3 +13,9 @@ export const store = configureStore({
 
 export type ExploreState = ReturnType<typeof store.getState>;
 export type ExploreDispatch = typeof store.dispatch;
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  ExploreState,
+  unknown,
+  Action<string>
+>;

--- a/src/pages/Explore/utils/index.ts
+++ b/src/pages/Explore/utils/index.ts
@@ -1,4 +1,13 @@
 import { centerKey, zoomKey } from "../components/Map/hooks/useUrlState";
+import {
+  renderQsKey,
+  mosaicQsKey,
+} from "../components/Sidebar/selectors/hooks/useUrlState";
+
+export const resetMosaicQueryStringState = () => {
+  updateQueryStringParam(renderQsKey, "");
+  updateQueryStringParam(mosaicQsKey, "");
+};
 
 export const updateQueryStringParam = (
   key: string,


### PR DESCRIPTION
Query strings are synced with the mosiac state is reset, so they must be
reset directly via a Thunk in the redux flow.