### PR TITLE
Reduce test flake

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "baseUrl": "http://localhost:3000",
-  "experimentalStudio": true
+  "defaultCommandTimeout": 8000,
+  "retries": { "runMode": 2 }
 }


### PR DESCRIPTION
Increase command timeout and re-test count for CI to prevent flake.