### PR TITLE
Use explicit return_mask on imagery tile requests

### DIFF
--- a/public/stac/landsat-8-c2-l2/mosaicInfo.json
+++ b/public/stac/landsat-8-c2-l2/mosaicInfo.json
@@ -175,13 +175,13 @@
     {
       "name": "Natural color",
       "description": "True color composite of visible bands (SR_B4, SR_B3, SR_B2)",
-      "options": "assets=SR_B4,SR_B3,SR_B2&nodata=0&color_formula=gamma RGB 2.7, saturation 1.5, sigmoidal RGB 15 0.55",
+      "options": "assets=SR_B4,SR_B3,SR_B2&nodata=0&return_mask=false&color_formula=gamma RGB 2.7, saturation 1.5, sigmoidal RGB 15 0.55",
       "minZoom": 8
     },
     {
       "name": "Color infrared",
       "description": "Highlights healthy (red) and unhealthy (blue/gray) vegetation (SR_B5, SR_B4, SR_B3).",
-      "options": "assets=SR_B5,SR_B4,SR_B3&nodata=0&color_formula=gamma RGB 2.7, saturation 1.5, sigmoidal RGB 15 0.55",
+      "options": "assets=SR_B5,SR_B4,SR_B3&nodata=0&return_mask=false&color_formula=gamma RGB 2.7, saturation 1.5, sigmoidal RGB 15 0.55",
       "minZoom": 8
     },
     {
@@ -193,7 +193,7 @@
     {
       "name": "Agriculture",
       "description": "Darker shades of green indicate denser vegetation (SR_B6, SR_B5, SR_B2).",
-      "options": "assets=SR_B6,SR_B5,SR_B2&nodata=0",
+      "options": "assets=SR_B6,SR_B5,SR_B2&nodata=0&return_mask=false",
       "minZoom": 8
     },
     {

--- a/public/stac/sentinel-2-l2a/mosaicInfo.json
+++ b/public/stac/sentinel-2-l2a/mosaicInfo.json
@@ -175,25 +175,25 @@
     {
       "name": "Natural color",
       "description": "True color composite of visible bands (B04, B03, B02)",
-      "options": "assets=B04,B03,B02&nodata=0&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
+      "options": "assets=B04,B03,B02&nodata=0&return_mask=false&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
       "minZoom": 9
     },
     {
       "name": "Color infrared",
       "description": "Highlights healthy (red) and unhealthy (blue/gray) vegetation (B08, B04, B03).",
-      "options": "assets=B08,B04,B03&nodata=0&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
+      "options": "assets=B08,B04,B03&nodata=0&return_mask=false&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
       "minZoom": 9
     },
     {
       "name": "Short wave infrared",
       "description": "Darker shades of green indicate denser vegetation. Brown is indicative of bare soil and built-up areas (B12, B8A, B04).",
-      "options": "assets=B12,B8A,B04&nodata=0&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
+      "options": "assets=B12,B8A,B04&nodata=0&return_mask=false&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
       "minZoom": 9
     },
     {
       "name": "Agriculture",
       "description": "Darker shades of green indicate denser vegetation (B11, B08, B02).",
-      "options": "assets=B11,B08,B02&nodata=0&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
+      "options": "assets=B11,B08,B02&nodata=0&return_mask=false&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
       "minZoom": 9
     },
     {


### PR DESCRIPTION
When using PNG format, return_mask default changes. For imagery datasets
that render correctly as JPG but need to be PNG for alpha channel, set
the return mask to false explicitly in the tile request.