### PR TITLE
Move mapInfo config to mosaicInfo

### DIFF
--- a/public/stac/3dep-seamless/mosaicInfo.json
+++ b/public/stac/3dep-seamless/mosaicInfo.json
@@ -29,5 +29,9 @@
       "options": "assets=data&rescale=-1000,4000&colormap_name=gray_r",
       "minZoom": 8
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 8,
+    "coordinates": [47.1113, -120.8578]
+  }
 }

--- a/public/stac/alos-dem/mosaicInfo.json
+++ b/public/stac/alos-dem/mosaicInfo.json
@@ -29,5 +29,9 @@
       "options": "assets=data&rescale=-1000,4000&colormap_name=gray_r",
       "minZoom": 8
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 8,
+    "coordinates": [35.6837, 138.4281]
+  }
 }

--- a/public/stac/aster-l1t/mosaicInfo.json
+++ b/public/stac/aster-l1t/mosaicInfo.json
@@ -67,5 +67,9 @@
       "options": "assets=VNIR&bidx=2,3,1&nodata=0&skipcovered=False&exitwhenfull=False&items_limit=15&time_limit=5&items_limit=15&",
       "minZoom": 9
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 9,
+    "coordinates": [37.2141, -104.2947]
+  }
 }

--- a/public/stac/cop-dem-glo-30/mosaicInfo.json
+++ b/public/stac/cop-dem-glo-30/mosaicInfo.json
@@ -29,5 +29,9 @@
       "options": "assets=data&rescale=-1000,4000&colormap_name=gray_r",
       "minZoom": 8
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 8,
+    "coordinates": [30.0572, 80.1735]
+  }
 }

--- a/public/stac/cop-dem-glo-90/mosaicInfo.json
+++ b/public/stac/cop-dem-glo-90/mosaicInfo.json
@@ -29,5 +29,9 @@
       "options": "assets=data&rescale=-1000,4000&colormap_name=gray_r",
       "minZoom": 8
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 8,
+    "coordinates": [46.8776, 12.1444]
+  }
 }

--- a/public/stac/gap/mosaicInfo.json
+++ b/public/stac/gap/mosaicInfo.json
@@ -16,5 +16,9 @@
       "options": "assets=data&exitwhenfull=False&skipcovered=False&colormap_name=gap-lulc",
       "minZoom": 5
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 7,
+    "coordinates": [26.7409, -80.9714]
+  }
 }

--- a/public/stac/goes-cmi/mosaicInfo.json
+++ b/public/stac/goes-cmi/mosaicInfo.json
@@ -34,5 +34,9 @@
       "options": "expression=C02_2km_wm,0.45*C02_2km_wm+0.1*C03_2km_wm+0.45*C01_2km_wm,C01_2km_wm&nodata=-1&rescale=1,3000&color_formula=Gamma RGB 2.5 Saturation 1.4 Sigmoidal RGB 2 0.7",
       "minZoom": 2
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 4,
+    "coordinates": [33.4872, -114.4842]
+  }
 }

--- a/public/stac/hgb/mosaicInfo.json
+++ b/public/stac/hgb/mosaicInfo.json
@@ -35,5 +35,9 @@
       "options": "assets=belowground_uncertainty&colormap_name=reds&nodata=0&rescale=0,50",
       "minZoom": 2
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 9,
+    "coordinates": [-7.641129, 39.162521]
+  }
 }

--- a/public/stac/hrea/mosaicInfo.json
+++ b/public/stac/hrea/mosaicInfo.json
@@ -99,5 +99,9 @@
       "options": "assets=night-proportion&colormap_name=magma&rescale=0,1&skipcovered=False&exitwhenfull=False",
       "minZoom": 3
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 3,
+    "coordinates": [11.828, 20.6367]
+  }
 }

--- a/public/stac/io-lulc/mosaicInfo.json
+++ b/public/stac/io-lulc/mosaicInfo.json
@@ -17,5 +17,9 @@
       "options": "assets=data&exitwhenfull=False&skipcovered=False&colormap_name=io-lulc",
       "minZoom": 4
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 4,
+    "coordinates": [-0.8749, 109.8456]
+  }
 }

--- a/public/stac/jrc-gsw/mosaicInfo.json
+++ b/public/stac/jrc-gsw/mosaicInfo.json
@@ -47,5 +47,9 @@
       "options": "assets=extent&colormap_name=jrc-extent&nodata=0",
       "minZoom": 4
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 10,
+    "coordinates": [24.21647, 91.015209]
+  }
 }

--- a/public/stac/landsat-8-c2-l2/mosaicInfo.json
+++ b/public/stac/landsat-8-c2-l2/mosaicInfo.json
@@ -214,5 +214,9 @@
       "options": "nodata=0&assets=SR_B7,SR_B6,SR_B5&color_formula=gamma RGB 2.7, saturation 1.5, sigmoidal RGB 15 0.55",
       "minZoom": 8
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 11,
+    "coordinates": [37.4069, 118.8188]
+  }
 }

--- a/public/stac/mobi/mosaicInfo.json
+++ b/public/stac/mobi/mosaicInfo.json
@@ -89,5 +89,9 @@
       "options": "assets=RSR_PollinatorInverts&colormap_name=magma&rescale=0,.001",
       "minZoom": 3
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 4,
+    "coordinates": [37.3052, -85.8457]
+  }
 }

--- a/public/stac/mtbs/mosaicInfo.json
+++ b/public/stac/mtbs/mosaicInfo.json
@@ -333,5 +333,9 @@
       "options": "assets=burn-severity&exitwhenfull=False&skipcovered=True&colormap_name=mtbs-severity",
       "minZoom": 3
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 9,
+    "coordinates": [39.2234, -122.6932]
+  }
 }

--- a/public/stac/naip/mosaicInfo.json
+++ b/public/stac/naip/mosaicInfo.json
@@ -119,5 +119,9 @@
       "options": "assets=image&asset_expression=(B4-B1)/(B4+B1)&rescale=-1,1&colormap_name=rdylgn",
       "minZoom": 12
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 13,
+    "coordinates": [36.0891, -111.8577]
+  }
 }

--- a/public/stac/nasadem/mosaicInfo.json
+++ b/public/stac/nasadem/mosaicInfo.json
@@ -28,5 +28,9 @@
       "options": "assets=elevation&rescale=-1000,4000&colormap_name=gray_r",
       "minZoom": 7
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 7,
+    "coordinates": [-10.727, -74.762]
+  }
 }

--- a/public/stac/sentinel-2-l2a/mosaicInfo.json
+++ b/public/stac/sentinel-2-l2a/mosaicInfo.json
@@ -214,5 +214,9 @@
       "options": "nodata=0&assets=B12,B11,B8A&color_formula=Gamma RGB 3.7 Saturation 1.5 Sigmoidal RGB 15 0.35",
       "minZoom": 9
     }
-  ]
+  ],
+  "defaultLocation": {
+    "zoom": 9,
+    "coordinates": [-16.494, 124.0274]
+  }
 }

--- a/src/components/LaunchInExplorer.tsx
+++ b/src/components/LaunchInExplorer.tsx
@@ -3,7 +3,7 @@ import centroid from "@turf/centroid";
 import * as qs from "query-string";
 
 import { IStacCollection } from "types/stac";
-import { useCollectionMapInfo } from "pages/Explore/utils/hooks";
+import { useCollectionMosaicInfo } from "pages/Explore/utils/hooks";
 import { isValidExplorer, spatialExtentToMultipolygon } from "utils/collections";
 
 interface LaunchInExplorerProps {
@@ -11,7 +11,7 @@ interface LaunchInExplorerProps {
 }
 
 const LaunchInExplorer = ({ collection }: LaunchInExplorerProps) => {
-  const { data: mapData } = useCollectionMapInfo(collection.id);
+  const { data: mapData } = useCollectionMosaicInfo(collection.id);
   if (!isValidExplorer(collection)) return null;
 
   const bbox = collection?.extent.spatial.bbox;
@@ -21,9 +21,11 @@ const LaunchInExplorer = ({ collection }: LaunchInExplorerProps) => {
   const collectionCenterCoords = centerPoint?.geometry.coordinates
     .map(n => n.toFixed(4))
     .join(",");
+  const defaultLocation = mapData?.defaultLocation;
   const center =
-    mapData?.initialCoords && [...mapData.initialCoords].reverse().join(",");
-  const zoom = mapData?.initialZoom || undefined;
+    defaultLocation?.coordinates &&
+    [...defaultLocation.coordinates].reverse().join(",");
+  const zoom = defaultLocation?.zoom || undefined;
 
   const params = {
     c: center || collectionCenterCoords,

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -1,6 +1,11 @@
+export interface IDefaultLocationInfo {
+  zoom: number;
+  coordinates: [number, number];
+}
 export interface IMosaicInfo {
   mosaics: IMosaic[];
   renderOptions: IMosaicRenderOption[] | null;
+  defaultLocation: IDefaultLocationInfo;
 }
 
 export interface IMosaic {

--- a/src/pages/Explore/utils/hooks/useCollectionMapInfo.ts
+++ b/src/pages/Explore/utils/hooks/useCollectionMapInfo.ts
@@ -3,6 +3,8 @@ import { IMapInfo } from "pages/Explore/types";
 import { QueryFunctionContext, useQuery } from "react-query";
 import { DATA_URL } from "utils/constants";
 
+/* DEPRECATED: mapInfo endpoint from the API has been deprecated and this information now
+lives in the mosaicInfo object. */
 export const useCollectionMapInfo = (collectionId: string) => {
   return useQuery(["mapinfo", collectionId], getCollectionViewerParams, {
     refetchOnWindowFocus: false,


### PR DESCRIPTION
The API previously provided default coordinates and zoom for datasets,
but that configuration was tied to the mechanism that provided early
sqlite-db generate mosaics. When this feature was disabled, the mapInfo
was unintentionally disabled. Consolidate this config with mosaic config,
though all of that eventually will migrate back to the API.