### PR TITLE
Fix filter results overflow issues

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, CSSProperties } from "react";
 import Header from "./Header";
 import Footer from "./Footer";
 import Announcement from "./Announcement";
@@ -10,6 +10,7 @@ interface Props {
   isShort?: boolean;
   onGrid?: boolean;
   allowAnnouncement?: boolean;
+  mainStyle?: CSSProperties;
 }
 
 const Layout: React.FC<Props> = ({
@@ -19,6 +20,7 @@ const Layout: React.FC<Props> = ({
   onGrid = true,
   children,
   allowAnnouncement = true,
+  mainStyle,
 }) => {
   return (
     <>
@@ -26,7 +28,9 @@ const Layout: React.FC<Props> = ({
       {allowAnnouncement && <Announcement />}
       {bannerHeader && <div>{bannerHeader}</div>}
       <ScrollToTopOnMount />
-      <main className={isShort ? "short" : undefined}>{children}</main>
+      <main className={isShort ? "short" : undefined} style={mainStyle}>
+        {children}
+      </main>
       {bannerFooter}
       <Footer onGrid={onGrid} />
     </>

--- a/src/pages/Explore/components/Sidebar/panes/SearchResultsPane.tsx
+++ b/src/pages/Explore/components/Sidebar/panes/SearchResultsPane.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   getTheme,
   IMessageBarStyles,
+  IStackStyles,
 } from "@fluentui/react";
 import { UseQueryResult } from "react-query";
 
@@ -97,20 +98,23 @@ const SearchResultsPane = ({
     return <ItemResult item={item} />;
   };
 
+  const resultsListStyle: Partial<IStackStyles> = {
+    root: {
+      background: theme.palette.neutralLighterAlt,
+      display: visible ? "flex" : "none",
+      height: "100%",
+      paddingLeft: 10,
+      paddingRight: 10,
+      paddingBottom: 1,
+      borderTop: `1px solid ${theme.palette.neutralLight}`,
+      overflowY: "auto",
+      overflowX: "hidden",
+    },
+  };
+
   return (
     <>
-      <Stack
-        styles={{
-          root: {
-            background: theme.palette.neutralLighterAlt,
-            display: visible ? "flex" : "none",
-            height: "100%",
-            paddingLeft: 10,
-            paddingRight: 10,
-            borderTop: `1px solid ${theme.palette.neutralLight}`,
-          },
-        }}
-      >
+      <Stack styles={resultsListStyle}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <SearchResultsHeader results={data} isLoading={isPreviousData} />
           <div className={scrollPos ? "hood on" : "hood"} />

--- a/src/pages/Explore/index.tsx
+++ b/src/pages/Explore/index.tsx
@@ -1,6 +1,7 @@
+import { CSSProperties } from "react";
 import { Provider } from "react-redux";
 import "azure-maps-control/dist/atlas.min.css";
-import { Stack, StackItem, useTheme } from "@fluentui/react";
+import { IStackStyles, Stack, StackItem, useTheme } from "@fluentui/react";
 
 import { store } from "./state/store";
 import "./explorer.css";
@@ -25,12 +26,13 @@ const Explorer = () => {
   const { height } = useWindowSize();
 
   const bodyHeight = height - heights.header - heights.footer - heights.buffer;
+  const mainStyle: CSSProperties = { height: bodyHeight };
 
   return (
-    <Layout onGrid={false} allowAnnouncement={false}>
+    <Layout onGrid={false} allowAnnouncement={false} mainStyle={mainStyle}>
       <SEO title="Explorer" description="Explore Planetary Computer datasets" />
       <Provider store={store}>
-        <Stack horizontal styles={{ root: { height: bodyHeight } }}>
+        <Stack horizontal styles={contentStyles}>
           <Sidebar />
           <StackItem
             styles={{
@@ -52,3 +54,9 @@ const Explorer = () => {
 };
 
 export default Explorer;
+
+const contentStyles: Partial<IStackStyles> = {
+  root: {
+    height: "100%",
+  },
+};


### PR DESCRIPTION
After refactoring the Explore search results layout to provide better
styling, the flex approach to keeping the various sidebar components
shrinking/growing in sync was broken. Restyles various heights to keep a
scrollable interface.