### PR TITLE
Add legend component

### DIFF
--- a/public/stac/aster-l1t/mosaicInfo.json
+++ b/public/stac/aster-l1t/mosaicInfo.json
@@ -14,7 +14,7 @@
       "cql": []
     },
     {
-      "name": "Most Recent: Fall 2006 (low-cloud)",
+      "name": "Most Recent: Oct – Dec 2006 (low-cloud)",
       "description": "",
       "cql": [
         {
@@ -24,7 +24,7 @@
       ]
     },
     {
-      "name": "Summer 2006 (low-cloud)",
+      "name": "Jul – Sep 2006 (low-cloud)",
       "description": "",
       "cql": [
         {
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "name": "Spring 2006 (low-cloud)",
+      "name": "Apr – Jun 2006 (low-cloud)",
       "description": "",
       "cql": [
         {
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "name": "Winter 2006 (low-cloud)",
+      "name": "Jan – Mar 2006 (low-cloud)",
       "description": "",
       "cql": [
         {

--- a/public/stac/goes-cmi/mosaicInfo.json
+++ b/public/stac/goes-cmi/mosaicInfo.json
@@ -26,13 +26,19 @@
       "name": "Natural color",
       "description": "Natural color representation with Green represented by formula: `0.45*C02_2km+0.1*C03_2km+0.45*C01_2km`",
       "options": "expression=C02_2km_wm,0.45*C02_2km_wm+0.1*C03_2km_wm+0.45*C01_2km_wm,C01_2km_wm&nodata=-1&rescale=1,2000&color_formula=Gamma RGB 2.5 Saturation 1.4 Sigmoidal RGB 2 0.7",
-      "minZoom": 2
+      "minZoom": 2,
+      "legend": {
+        "type": "none"
+      }
     },
     {
       "name": "Natural color (low contrast)",
       "description": "Lower contrast natural color representation with Green represented by formula: `0.45*C02_2km+0.1*C03_2km+0.45*C01_2km`",
       "options": "expression=C02_2km_wm,0.45*C02_2km_wm+0.1*C03_2km_wm+0.45*C01_2km_wm,C01_2km_wm&nodata=-1&rescale=1,3000&color_formula=Gamma RGB 2.5 Saturation 1.4 Sigmoidal RGB 2 0.7",
-      "minZoom": 2
+      "minZoom": 2,
+      "legend": {
+        "type": "none"
+      }
     }
   ],
   "defaultLocation": {

--- a/public/stac/jrc-gsw/mosaicInfo.json
+++ b/public/stac/jrc-gsw/mosaicInfo.json
@@ -15,25 +15,47 @@
       "name": "Water occurrence",
       "description": "Shows where surface water occurred between 1984 and 2020",
       "options": "assets=occurrence&colormap_name=jrc-occurrence&nodata=0",
-      "minZoom": 4
+      "minZoom": 4,
+      "legend": {
+        "type": "continuous",
+        "labels": ["Sometimes water", "Always water"],
+        "trimStart": 1
+      }
     },
     {
       "name": "Annual water recurrence",
       "description": "Shows frequency that water returns from one year to another",
       "options": "assets=recurrence&colormap_name=jrc-recurrence&nodata=0",
-      "minZoom": 4
+      "minZoom": 4,
+      "legend": {
+        "type": "continuous",
+        "labels": [">0%", "100%"],
+        "trimStart": 1,
+        "trimEnd": 2
+      }
     },
     {
       "name": "Water Occurrence change intensity",
       "description": "Shows where surface water occurrence increased, decreased, or did not change between 1984 and 2020",
       "options": "assets=change&colormap_name=jrc-change&nodata=0",
-      "minZoom": 4
+      "minZoom": 4,
+      "legend": {
+        "type": "continuous",
+        "labels": ["Decrease", "No change", "Increase"],
+        "trimEnd": 3
+      }
     },
     {
       "name": "Water seasonality",
       "description": "Indicates more seasonal or permanent surface water features during the course of a year",
       "options": "assets=seasonality&colormap_name=jrc-seasonality&nodata=0",
-      "minZoom": 4
+      "minZoom": 4,
+      "legend": {
+        "type": "continuous",
+        "labels": ["Seasonal", "Permanent"],
+        "trimStart": 1,
+        "trimEnd": 1
+      }
     },
     {
       "name": "Water transitions",

--- a/public/stac/landsat-8-c2-l2/mosaicInfo.json
+++ b/public/stac/landsat-8-c2-l2/mosaicInfo.json
@@ -11,7 +11,7 @@
       "cql": []
     },
     {
-      "name": "Fall 2021 (low cloud)",
+      "name": "Sep – Nov, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -21,7 +21,7 @@
       ]
     },
     {
-      "name": "Summer 2021 (low cloud)",
+      "name": "Jun – Aug, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -31,7 +31,7 @@
       ]
     },
     {
-      "name": "Spring 2021 (low cloud)",
+      "name": "Mar – May, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -41,7 +41,7 @@
       ]
     },
     {
-      "name": "Winter 2021 (low cloud)",
+      "name": "Dec – Feb, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "name": "Fall 2020 (low cloud)",
+      "name": "Sep – Nov, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -61,7 +61,7 @@
       ]
     },
     {
-      "name": "Summer 2020 (low cloud)",
+      "name": "Jun – Aug, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -71,7 +71,7 @@
       ]
     },
     {
-      "name": "Spring 2020 (low cloud)",
+      "name": "Mar – May, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -81,7 +81,7 @@
       ]
     },
     {
-      "name": "Winter 2020 (low cloud)",
+      "name": "Dec – Feb, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -91,7 +91,7 @@
       ]
     },
     {
-      "name": "Fall 2019 (low cloud)",
+      "name": "Sep – Nov, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "name": "Summer 2019 (low cloud)",
+      "name": "Jun – Aug, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -111,7 +111,7 @@
       ]
     },
     {
-      "name": "Spring 2019 (low cloud)",
+      "name": "Mar – May, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -121,7 +121,7 @@
       ]
     },
     {
-      "name": "Winter 2019 (low cloud)",
+      "name": "Dec – Feb, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -131,7 +131,7 @@
       ]
     },
     {
-      "name": "Fall 2018 (low cloud)",
+      "name": "Sep – Nov, 2018 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -141,7 +141,7 @@
       ]
     },
     {
-      "name": "Summer 2018 (low cloud)",
+      "name": "Jun – Aug, 2018 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -151,7 +151,7 @@
       ]
     },
     {
-      "name": "Spring 2018 (low cloud)",
+      "name": "Mar – May, 2018 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -161,7 +161,7 @@
       ]
     },
     {
-      "name": "Winter 2018 (low cloud)",
+      "name": "Dec – Feb, 2018 (low cloud)",
       "description": "",
       "cql": [
         {

--- a/public/stac/sentinel-2-l2a/mosaicInfo.json
+++ b/public/stac/sentinel-2-l2a/mosaicInfo.json
@@ -11,7 +11,7 @@
       "cql": []
     },
     {
-      "name": "Fall 2021 (low cloud)",
+      "name": "Sep – Nov, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -21,7 +21,7 @@
       ]
     },
     {
-      "name": "Summer 2021 (low cloud)",
+      "name": "Jun – Aug, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -31,7 +31,7 @@
       ]
     },
     {
-      "name": "Spring 2021 (low cloud)",
+      "name": "Mar – May, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -41,7 +41,7 @@
       ]
     },
     {
-      "name": "Winter 2021 (low cloud)",
+      "name": "Dec – Feb, 2021 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "name": "Fall 2020 (low cloud)",
+      "name": "Sep – Nov, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -61,7 +61,7 @@
       ]
     },
     {
-      "name": "Summer 2020 (low cloud)",
+      "name": "Jun – Aug, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -71,7 +71,7 @@
       ]
     },
     {
-      "name": "Spring 2020 (low cloud)",
+      "name": "Mar – May, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -81,7 +81,7 @@
       ]
     },
     {
-      "name": "Winter 2020 (low cloud)",
+      "name": "Dec – Feb, 2020 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -91,7 +91,7 @@
       ]
     },
     {
-      "name": "Fall 2019 (low cloud)",
+      "name": "Sep – Nov, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "name": "Summer 2019 (low cloud)",
+      "name": "Jun – Aug, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -114,7 +114,7 @@
       ]
     },
     {
-      "name": "Spring 2019 (low cloud)",
+      "name": "Mar – May, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -124,7 +124,7 @@
       ]
     },
     {
-      "name": "Winter 2019 (low cloud)",
+      "name": "Dec – Feb, 2019 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -134,7 +134,7 @@
       ]
     },
     {
-      "name": "Fall 2018 (low cloud)",
+      "name": "Sep – Nov, 2018 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -144,7 +144,7 @@
       ]
     },
     {
-      "name": "Summer 2018 (low cloud)",
+      "name": "Jun – Aug, 2018 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -154,7 +154,7 @@
       ]
     },
     {
-      "name": "Spring 2018 (low cloud)",
+      "name": "Mar – May, 2018 (low cloud)",
       "description": "",
       "cql": [
         {
@@ -164,7 +164,7 @@
       ]
     },
     {
-      "name": "Winter 2018 (low cloud)",
+      "name": "Dec – Feb, 2018 (low cloud)",
       "description": "",
       "cql": [
         {

--- a/src/pages/Explore/components/Map/components/LegendControl/ClassMap.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/ClassMap.tsx
@@ -1,0 +1,12 @@
+import { Text } from "@fluentui/react";
+import * as qs from "query-string";
+
+interface ClassMapProps {
+  params: qs.ParsedQuery<string>;
+}
+
+const ClassMap = ({ params }: ClassMapProps) => {
+  return <Text>Classmap TBD</Text>;
+};
+
+export default ClassMap;

--- a/src/pages/Explore/components/Map/components/LegendControl/ClassMap.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/ClassMap.tsx
@@ -1,12 +1,111 @@
-import { Text } from "@fluentui/react";
+import {
+  FontSizes,
+  getTheme,
+  IStackItemStyles,
+  IStackTokens,
+  ITextStyles,
+  Shimmer,
+  ShimmerElementType,
+  Stack,
+  StackItem,
+  Text,
+} from "@fluentui/react";
 import * as qs from "query-string";
+import { IStacCollection } from "types/stac";
+import { getClassNameByValue, useClassmap } from "./helpers";
 
 interface ClassMapProps {
   params: qs.ParsedQuery<string>;
+  collection: IStacCollection | null;
 }
 
-const ClassMap = ({ params }: ClassMapProps) => {
-  return <Text>Classmap TBD</Text>;
+const ClassMap = ({ params, collection }: ClassMapProps) => {
+  const classmapName = Array.isArray(params.colormap_name)
+    ? params.colormap_name[0]
+    : params.colormap_name;
+
+  const { isLoading, data: classes } = useClassmap(classmapName);
+  const loading = isLoading && (
+    <Shimmer
+      shimmerElements={[{ type: ShimmerElementType.line, height: 20, width: 233 }]}
+    />
+  );
+
+  const assetName = Array.isArray(params.assets) ? params.assets[0] : params.assets;
+  if (!assetName) return null;
+
+  const asset = collection?.item_assets[assetName];
+  if (!asset) return null;
+
+  const classValues = asset["file:values"];
+  if (!classValues) return null;
+
+  const legendItems = classes
+    ? Object.keys(classes).map(key => {
+        const color = classes[key];
+        const label = getClassNameByValue(key, classValues);
+        const elKey = `legend-class-${key}`;
+
+        // There may have been a mismatch in class values and the classmap. Only return
+        // a legend item if there was a defined class value.
+        return (
+          label && (
+            <Stack
+              key={elKey}
+              horizontal
+              verticalAlign="center"
+              tokens={itemStackTokens}
+            >
+              <ColorSwatch color={color} />
+              <Text styles={itemTextStyles}>{label}</Text>
+            </Stack>
+          )
+        );
+      })
+    : null;
+
+  return (
+    <StackItem styles={legendStyles} className="custom-overflow">
+      {loading}
+      <Stack tokens={legendStackTokens}>{legendItems}</Stack>
+    </StackItem>
+  );
+};
+
+const theme = getTheme();
+const ColorSwatch = ({ color }: { color: number[] }) => {
+  return (
+    <div
+      style={{
+        backgroundColor: `rgba(${color.join(",")}) `,
+        width: 10,
+        height: 10,
+        borderRadius: "50%",
+        borderWidth: 0.5,
+        borderStyle: "solid",
+        borderColor: theme.palette.neutralQuaternary,
+      }}
+    />
+  );
 };
 
 export default ClassMap;
+
+const itemStackTokens: IStackTokens = {
+  childrenGap: 5,
+};
+const legendStackTokens: IStackTokens = {
+  childrenGap: 5,
+};
+const itemTextStyles: Partial<ITextStyles> = {
+  root: {
+    fontSize: FontSizes.smallPlus,
+  },
+};
+const legendStyles: IStackItemStyles = {
+  root: {
+    maxHeight: 150,
+    overflowY: "auto",
+    overflowX: "hidden",
+  },
+};

--- a/src/pages/Explore/components/Map/components/LegendControl/ColorMap.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/ColorMap.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from "react";
+import { useBoolean } from "react-use";
 import {
   FontSizes,
   IImageStyles,
@@ -6,20 +8,23 @@ import {
   Stack,
   Text,
   getTheme,
+  ImageLoadState,
+  Shimmer,
+  ShimmerElementType,
 } from "@fluentui/react";
 import * as qs from "query-string";
-import { DATA_URL } from "utils/constants";
+
+import { rootColormapUrl } from "./helpers";
 
 const HEIGHT: number = 0.08;
-const WIDTH: number = 3.5;
+const WIDTH: number = 3;
 
 interface ColorMapProps {
   params: qs.ParsedQuery<string>;
 }
 
 const ColorMap = ({ params }: ColorMapProps) => {
-  console.log(params);
-  const img = makeColorRamp(params.colormap_name);
+  const img = useColorRamp(params.colormap_name);
   const scale = makeScale(params.rescale);
 
   return (
@@ -32,14 +37,32 @@ const ColorMap = ({ params }: ColorMapProps) => {
 
 export default ColorMap;
 
-const makeColorRamp = (colormapName: string | string[] | null) => {
+const useColorRamp = (colormapName: string | string[] | null) => {
+  const [loading, setLoading] = useBoolean(true);
+
+  const handleStateChange = useCallback(
+    (state: ImageLoadState) => {
+      setLoading(state === ImageLoadState.notLoaded);
+    },
+    [setLoading]
+  );
   if (!colormapName) return null;
 
   return (
-    <Image
-      styles={imageStyles}
-      src={`${DATA_URL}/legend/colormap/${colormapName}?height=${HEIGHT}&width=${WIDTH}`}
-    />
+    <>
+      {loading && (
+        <Shimmer
+          shimmerElements={[
+            { type: ShimmerElementType.line, height: 8, width: 233 },
+          ]}
+        />
+      )}
+      <Image
+        styles={imageStyles}
+        src={`${rootColormapUrl}/${colormapName}?height=${HEIGHT}&width=${WIDTH}`}
+        onLoadingStateChange={handleStateChange}
+      />
+    </>
   );
 };
 

--- a/src/pages/Explore/components/Map/components/LegendControl/ColorMap.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/ColorMap.tsx
@@ -1,0 +1,75 @@
+import {
+  FontSizes,
+  IImageStyles,
+  Image,
+  ITextStyles,
+  Stack,
+  Text,
+  getTheme,
+} from "@fluentui/react";
+import * as qs from "query-string";
+import { DATA_URL } from "utils/constants";
+
+const HEIGHT: number = 0.08;
+const WIDTH: number = 3.5;
+
+interface ColorMapProps {
+  params: qs.ParsedQuery<string>;
+}
+
+const ColorMap = ({ params }: ColorMapProps) => {
+  console.log(params);
+  const img = makeColorRamp(params.colormap_name);
+  const scale = makeScale(params.rescale);
+
+  return (
+    <Stack>
+      {img}
+      {scale}
+    </Stack>
+  );
+};
+
+export default ColorMap;
+
+const makeColorRamp = (colormapName: string | string[] | null) => {
+  if (!colormapName) return null;
+
+  return (
+    <Image
+      styles={imageStyles}
+      src={`${DATA_URL}/legend/colormap/${colormapName}?height=${HEIGHT}&width=${WIDTH}`}
+    />
+  );
+};
+
+const makeScale = (rescale: string | string[] | null) => {
+  const scale = Array.isArray(rescale) ? rescale[0] : rescale;
+  if (!scale) return null;
+
+  const [low, high] = scale.split(",").map(s => parseFloat(s));
+  const mid = (low + high) / 2;
+  return (
+    <Stack horizontal horizontalAlign="space-between">
+      <Text styles={scaleStyles}>{low}</Text>
+      <Text styles={scaleStyles}>{mid}</Text>
+      <Text styles={scaleStyles}>{high}</Text>
+    </Stack>
+  );
+};
+
+const theme = getTheme();
+const scaleStyles: ITextStyles = {
+  root: {
+    fontSize: FontSizes.small,
+  },
+};
+
+const imageStyles: Partial<IImageStyles> = {
+  image: {
+    borderRadius: 4,
+    borderWidth: 0.5,
+    borderColor: theme.palette.neutralQuaternary,
+    borderStyle: "solid",
+  },
+};

--- a/src/pages/Explore/components/Map/components/LegendControl/LegendControl.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/LegendControl.tsx
@@ -8,8 +8,11 @@ import {
   IStackTokens,
   StackItem,
   FontSizes,
+  IconButton,
+  IButtonStyles,
 } from "@fluentui/react";
 import * as qs from "query-string";
+import { useLocalStorage } from "react-use";
 
 import { ILegendConfig } from "pages/Explore/types";
 import { LegendTypes } from "pages/Explore/enums";
@@ -18,10 +21,12 @@ import ColorMap from "./ColorMap";
 import ClassMap from "./ClassMap";
 import { hasClassmapValues } from "./helpers";
 import { IStacCollection } from "types/stac";
+import { controlStyle } from "../PanelControl";
 
 export const LegendControl = () => {
   const renderOpts = useExploreSelector(s => s.mosaic.renderOption);
   const collection = useExploreSelector(s => s.mosaic.collection);
+  const [isOpen, setIsOpen] = useLocalStorage("legend-control-open", true);
 
   if (!renderOpts) return null;
 
@@ -36,19 +41,43 @@ export const LegendControl = () => {
     ) : null;
 
   // If the legend was configured or determined to not be needed, don't render it
-  if (!legend) return null;
 
-  return (
+  const legendPanel = (
     <Stack styles={panelStyles} tokens={stackTokens}>
       <StackItem>
-        <Text block styles={headerStyles}>
-          {collection?.title}
-        </Text>
+        <Stack horizontal horizontalAlign="space-between">
+          <Text block styles={headerStyles}>
+            {collection?.title}
+          </Text>
+          <IconButton
+            title="Hide Legend"
+            iconProps={{ iconName: "ChevronDown" }}
+            styles={minimizeButtonStyles}
+            onClick={() => setIsOpen(!isOpen)}
+          />
+        </Stack>
         {renderDesc}
       </StackItem>
       {legend}
     </Stack>
   );
+
+  const buttonStyle = { right: 2, bottom: 32, ...controlStyle };
+  const legendButton = (
+    <div style={buttonStyle}>
+      <IconButton
+        ariaLabel={legend ? "Open legend" : "No legend available"}
+        title={"Open legend"}
+        onClick={() => setIsOpen(true)}
+        disabled={!legend}
+        styles={legendButtonStyles}
+        className="azure-maps-control-button"
+        iconProps={{ iconName: "ThumbnailView" }}
+      />
+    </div>
+  );
+
+  return isOpen && legend ? legendPanel : legendButton;
 };
 
 const getLegendType = (
@@ -87,7 +116,7 @@ const panelStyles: IStackStyles = {
   root: {
     background: theme.semanticColors.bodyBackground,
     padding: 10,
-    borderRadius: 4,
+    borderRadius: 2,
     position: "absolute",
     zIndex: 1,
     bottom: 40,
@@ -106,5 +135,20 @@ const headerStyles: ITextStyles = {
 const subHeaderStyles: ITextStyles = {
   root: {
     fontSize: FontSizes.smallPlus,
+  },
+};
+
+const legendButtonStyles: IButtonStyles = {
+  icon: { color: theme.semanticColors.bodyText },
+};
+
+const minimizeButtonStyles: IButtonStyles = {
+  root: {
+    width: 18,
+    height: 18,
+  },
+  icon: {
+    color: theme.semanticColors.bodyText,
+    fontSize: FontSizes.xSmall,
   },
 };

--- a/src/pages/Explore/components/Map/components/LegendControl/LegendControl.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/LegendControl.tsx
@@ -1,0 +1,86 @@
+import {
+  FontWeights,
+  IStackStyles,
+  ITextStyles,
+  Stack,
+  Text,
+  getTheme,
+  IStackTokens,
+  StackItem,
+} from "@fluentui/react";
+import * as qs from "query-string";
+
+import { ILegendConfig } from "pages/Explore/types";
+import { LegendTypes } from "pages/Explore/enums";
+import { useExploreSelector } from "pages/Explore/state/hooks";
+import ColorMap from "./ColorMap";
+import ClassMap from "./ClassMap";
+
+export const LegendControl = () => {
+  const renderOpts = useExploreSelector(s => s.mosaic.renderOption);
+  const title = useExploreSelector(s => s.mosaic.collection?.title);
+
+  if (!renderOpts) return null;
+
+  const renderConfig = qs.parse(renderOpts.options || "");
+  const legendConfig = renderOpts.legend;
+  const legend = getLegendType(renderConfig, legendConfig);
+
+  // If the legend was configured or determined to not be needed, don't render it
+  if (!legend) return null;
+
+  return (
+    <Stack styles={panelStyles} tokens={stackTokens}>
+      <StackItem>
+        <Text block styles={headerStyles}>
+          {title}
+        </Text>
+        <Text block>{renderOpts.name}</Text>
+      </StackItem>
+      <StackItem>{legend}</StackItem>
+    </Stack>
+  );
+};
+
+const getLegendType = (
+  params: qs.ParsedQuery<string>,
+  legendConfig: ILegendConfig | undefined
+) => {
+  // Legend configs are optional, but if they exist, use them to set the values
+  if (legendConfig) {
+    switch (legendConfig.type) {
+      case LegendTypes.classmap:
+        return <ClassMap params={params} />;
+      case LegendTypes.continuous:
+        return <ColorMap params={params} />;
+      case LegendTypes.none:
+        return null;
+    }
+  }
+
+  if ("rescale" in params) {
+    return <ColorMap params={params} />;
+  }
+};
+
+const theme = getTheme();
+const stackTokens: IStackTokens = {
+  childrenGap: theme.spacing.s1,
+};
+const panelStyles: IStackStyles = {
+  root: {
+    background: theme.semanticColors.bodyBackground,
+    padding: 10,
+    borderRadius: 4,
+    position: "absolute",
+    zIndex: 1,
+    bottom: 40,
+    right: 10,
+  },
+};
+
+const headerStyles: ITextStyles = {
+  root: {
+    fontWeight: FontWeights.semibold,
+  },
+};

--- a/src/pages/Explore/components/Map/components/LegendControl/LegendControl.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/LegendControl.tsx
@@ -7,6 +7,7 @@ import {
   getTheme,
   IStackTokens,
   StackItem,
+  FontSizes,
 } from "@fluentui/react";
 import * as qs from "query-string";
 
@@ -29,7 +30,9 @@ export const LegendControl = () => {
   const legend = getLegendType(renderConfig, legendConfig, collection);
   const renderDesc =
     renderOpts.name && renderOpts?.name !== "Default" ? (
-      <Text block>{renderOpts.name}</Text>
+      <Text block styles={subHeaderStyles}>
+        {renderOpts.name}
+      </Text>
     ) : null;
 
   // If the legend was configured or determined to not be needed, don't render it
@@ -59,14 +62,16 @@ const getLegendType = (
       case LegendTypes.classmap:
         return <ClassMap params={params} collection={collection} />;
       case LegendTypes.continuous:
-        return <ColorMap params={params} />;
+        return <ColorMap params={params} legendConfig={legendConfig} />;
       case LegendTypes.none:
         return null;
+      default:
+        throw new Error(`Unknown legend type: ${legendConfig.type}`);
     }
   }
 
   if ("rescale" in params) {
-    return <ColorMap params={params} />;
+    return <ColorMap params={params} legendConfig={legendConfig} />;
   }
 
   if (hasClassmapValues(collection, params.assets)) {
@@ -87,11 +92,19 @@ const panelStyles: IStackStyles = {
     zIndex: 1,
     bottom: 40,
     right: 10,
+    boxShadow: "rgb(0 0 0 / 16%) 0 0 4px",
+    width: 300,
   },
 };
 
 const headerStyles: ITextStyles = {
   root: {
     fontWeight: FontWeights.semibold,
+  },
+};
+
+const subHeaderStyles: ITextStyles = {
+  root: {
+    fontSize: FontSizes.smallPlus,
   },
 };

--- a/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
+++ b/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
@@ -14,7 +14,7 @@ export const hasClassmapValues = (
   if (!assets) return false;
 
   // Unclear how we would handle multiple categorical assets at once
-  if (Array.isArray(assets)) return false;
+  if (Array.isArray(assets) || assets.includes(",")) return false;
 
   // Check the collection for item_asset for the selected asset, and see if it uses file:values
   // which defines the labels for the categorical values

--- a/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
+++ b/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { QueryFunctionContext, useQuery } from "react-query";
+import { FileExtValues, IStacCollection } from "types/stac";
+import { DATA_URL } from "utils/constants";
+
+export const rootColormapUrl = `${DATA_URL}/legend/colormap`;
+export const rootClassmapUrl = `${DATA_URL}/legend/classmap`;
+
+export const hasClassmapValues = (
+  collection: IStacCollection | null,
+  assets: string | string[] | null
+) => {
+  // If the rendering options don't include an asset, it's not a categorical
+  if (!assets) return false;
+
+  // Unclear how we would handle multiple categorical assets at once
+  if (Array.isArray(assets)) return false;
+
+  // Check the collection for item_asset for the selected asset, and see if it uses file:values
+  // which defines the labels for the categorical values
+  return collection && "file:values" in collection.item_assets[assets];
+};
+
+export const useClassmap = (classmapName: string | null) => {
+  return useQuery(["classmap", classmapName], getClassmapByName, {
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    enabled: Boolean(classmapName),
+  });
+};
+
+const getClassmapByName = async (
+  queryParam: QueryFunctionContext<["classmap", string | null]>
+): Promise<Record<string, number[]>> => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_, classmapName] = queryParam.queryKey;
+
+  return await (
+    await axios.get(`${rootClassmapUrl}/${classmapName}`)
+  ).data;
+};
+
+export const getClassNameByValue = (value: string, fileValues: FileExtValues[]) => {
+  const matchingValue = fileValues.find(fv => fv.values.includes(Number(value)));
+  return matchingValue?.summary;
+};

--- a/src/pages/Explore/components/Map/components/LegendControl/index.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/index.tsx
@@ -1,16 +1,1 @@
-import { Text } from "@fluentui/react";
-import PanelControl from "../PanelControl";
-
-const LegendControl = () => {
-  const title = "Legend";
-
-  return (
-    <PanelControl label={title} iconName="ThumbnailView" bottom={2} left={2}>
-      <Text block styles={{ root: { padding: 4 } }}>
-        Legend currently unavailable
-      </Text>
-    </PanelControl>
-  );
-};
-
-export default LegendControl;
+export { LegendControl as default } from "./LegendControl";

--- a/src/pages/Explore/components/Map/components/PanelControl/index.tsx
+++ b/src/pages/Explore/components/Map/components/PanelControl/index.tsx
@@ -1,5 +1,11 @@
 import React, { useImperativeHandle } from "react";
-import { getTheme, Callout, DirectionalHint, IconButton } from "@fluentui/react";
+import {
+  getTheme,
+  Callout,
+  DirectionalHint,
+  IconButton,
+  Stack,
+} from "@fluentui/react";
 import { useBoolean, useId } from "@fluentui/react-hooks";
 
 interface PanelControlProps {
@@ -49,7 +55,7 @@ const PanelControl = React.forwardRef<
       ? DirectionalHint.rightTopEdge
       : DirectionalHint.leftTopEdge;
     return (
-      <div style={buttonStyle}>
+      <Stack style={buttonStyle}>
         <IconButton
           id={buttonId}
           ariaLabel={label}
@@ -71,14 +77,14 @@ const PanelControl = React.forwardRef<
             {children}
           </Callout>
         )}
-      </div>
+      </Stack>
     );
   }
 );
 
 export default PanelControl;
 
-const controlStyle: React.CSSProperties = {
+export const controlStyle: React.CSSProperties = {
   zIndex: 1,
   position: "absolute",
   display: "flex",

--- a/src/pages/Explore/components/Map/components/PanelControl/index.tsx
+++ b/src/pages/Explore/components/Map/components/PanelControl/index.tsx
@@ -45,7 +45,9 @@ const PanelControl = React.forwardRef<
       },
     }));
 
-    const panelDir = left ? DirectionalHint.rightCenter : DirectionalHint.leftCenter;
+    const panelDir = left
+      ? DirectionalHint.rightTopEdge
+      : DirectionalHint.leftTopEdge;
     return (
       <div style={buttonStyle}>
         <IconButton

--- a/src/pages/Explore/enums.ts
+++ b/src/pages/Explore/enums.ts
@@ -1,0 +1,7 @@
+// Note that enums can't be exported from a types.d.ts file, so must have their own.
+
+export enum LegendTypes {
+  classmap = "classmap",
+  continuous = "continuous",
+  none = "none",
+}

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -30,7 +30,10 @@ export interface IMosaicRenderOption {
 }
 
 export interface ILegendConfig {
-  type: LegendTypes;
+  type?: LegendTypes;
+  labels?: string[];
+  trimStart?: number;
+  trimEnd?: number;
 }
 
 export interface IMapInfo {

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -1,3 +1,4 @@
+import { LegendTypes } from "./enums";
 import { ICqlExpressionList } from "./utils/cql/types";
 
 export interface IDefaultLocationInfo {
@@ -25,6 +26,11 @@ export interface IMosaicRenderOption {
   description: string;
   options: string;
   minZoom: number | undefined;
+  legend: ILegendConfig | undefined;
+}
+
+export interface ILegendConfig {
+  type: LegendTypes;
 }
 
 export interface IMapInfo {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -442,19 +442,19 @@ https://every-layout.dev/layouts/sidebar/
 }
 
 .custom-overflow::-webkit-scrollbar {
-  width: 10px;
+  width: 8px;
   background-color: #f5f5f5;
 }
 
 .custom-overflow::-webkit-scrollbar-thumb {
-  border-radius: 10px;
+  border-radius: 8px;
   box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.3);
   background-color: #ccc;
 }
 
 .custom-overflow::-webkit-scrollbar-track {
   box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.3);
-  border-radius: 10px;
+  border-radius: 8px;
   background-color: #fff;
 }
 

--- a/src/types/stac.d.ts
+++ b/src/types/stac.d.ts
@@ -39,8 +39,13 @@ export interface IStacAsset {
   description?: string;
   type?: string;
   roles?: string[];
+  "file:values"?: FileExtValues[];
 }
 
+export interface FileExtValues {
+  values: number[];
+  summary: string;
+}
 export interface IStacFilter {
   filter: Record<string, any>;
   limit?: number;


### PR DESCRIPTION
Supports automatically determining a legend type based off of titiler rendering parameters. Includes an optional configuration to force type, or supply additional legend rendering args. Both "continuous" (i.e., color ramp) and "classmap" (i.e., categorical) types are supported.