### PR TITLE
Interval legend type and start/end datetimes for item

### DIFF
--- a/src/pages/Explore/components/Map/components/LegendControl/Legend.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/Legend.tsx
@@ -15,13 +15,14 @@ import * as qs from "query-string";
 
 import { ILayerState, ILegendConfig } from "pages/Explore/types";
 import { LegendTypes } from "pages/Explore/enums";
-import ColorMap from "./ColorMap";
-import ClassMap from "./ClassMap";
+import ColorMap from "./legendTypes/ColorMap";
+import ClassMap from "./legendTypes/ClassMap";
 import { hasClassmapValues } from "./helpers";
 import { IStacCollection } from "types/stac";
 
 import LegendCmdBar from "./LegendCmdBar";
 import { useExploreSelector } from "pages/Explore/state/hooks";
+import Interval from "./legendTypes/Interval";
 interface LegendProps {
   layer: ILayerState;
 }
@@ -103,6 +104,8 @@ const getLegendType = (
         return <ClassMap params={params} collection={collection} />;
       case LegendTypes.continuous:
         return <ColorMap params={params} legendConfig={legendConfig} />;
+      case LegendTypes.interval:
+        return <Interval params={params} legendConfig={legendConfig} />;
       case LegendTypes.none:
         return null;
       default:

--- a/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
+++ b/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
@@ -7,6 +7,10 @@ import { DATA_URL } from "utils/constants";
 export const rootColormapUrl = `${DATA_URL}/legend/colormap`;
 export const rootClassmapUrl = `${DATA_URL}/legend/classmap`;
 
+// [[[min, max], [r,g,b,a]],...]
+export type IntervalMap = [[number, number], [number, number, number, number]][];
+export type ClassMap = Record<string, number[]>;
+
 export const hasClassmapValues = (
   collection: IStacCollection | null,
   assets: QsParamType
@@ -31,8 +35,8 @@ export const useClassmap = (classmapName: string | null) => {
 };
 
 const getClassmapByName = async (
-  queryParam: QueryFunctionContext<["classmap", string | null]>
-): Promise<Record<string, number[]>> => {
+  queryParam: QueryFunctionContext<["classmap" | "interval", string | null]>
+): Promise<ClassMap> => {
   const [, classmapName] = queryParam.queryKey;
 
   return await (
@@ -43,4 +47,22 @@ const getClassmapByName = async (
 export const getClassNameByValue = (value: string, fileValues: FileExtValues[]) => {
   const matchingValue = fileValues.find(fv => fv.values.includes(Number(value)));
   return matchingValue?.summary;
+};
+
+export const useInterval = (intervalName: string | null) => {
+  return useQuery(["interval", intervalName], getIntervalClassmapByName, {
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    enabled: Boolean(intervalName),
+  });
+};
+
+const getIntervalClassmapByName = async (
+  queryParam: QueryFunctionContext<["classmap" | "interval", string | null]>
+): Promise<IntervalMap> => {
+  const [, classmapName] = queryParam.queryKey;
+
+  return await (
+    await axios.get(`${rootClassmapUrl}/${classmapName}`)
+  ).data;
 };

--- a/src/pages/Explore/components/Map/components/LegendControl/legendTypes/ClassMap.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/legendTypes/ClassMap.tsx
@@ -12,7 +12,7 @@ import {
 } from "@fluentui/react";
 import * as qs from "query-string";
 import { IStacCollection } from "types/stac";
-import { getClassNameByValue, useClassmap } from "./helpers";
+import { getClassNameByValue, useClassmap } from "../helpers";
 
 interface ClassMapProps {
   params: qs.ParsedQuery<string>;
@@ -54,12 +54,12 @@ const ClassMap = ({ params, collection }: ClassMapProps) => {
               key={elKey}
               horizontal
               verticalAlign="center"
-              tokens={itemStackTokens}
+              tokens={mappedItemStackTokens}
             >
               <StackItem shrink={0}>
                 <ColorSwatch color={color} />
               </StackItem>
-              <Text styles={itemTextStyles}>{label}</Text>
+              <Text styles={mappedItemTextStyles}>{label}</Text>
             </Stack>
           )
         );
@@ -67,15 +67,15 @@ const ClassMap = ({ params, collection }: ClassMapProps) => {
     : null;
 
   return (
-    <StackItem styles={legendStyles} className="custom-overflow">
+    <StackItem styles={mappedItemLegendStyles} className="custom-overflow">
       {loading}
-      <Stack tokens={legendStackTokens}>{legendItems}</Stack>
+      <Stack tokens={mappedItemLegendStackTokens}>{legendItems}</Stack>
     </StackItem>
   );
 };
 
 const theme = getTheme();
-const ColorSwatch = ({ color }: { color: number[] }) => {
+export const ColorSwatch = ({ color }: { color: number[] }) => {
   return (
     <div
       style={{
@@ -93,18 +93,21 @@ const ColorSwatch = ({ color }: { color: number[] }) => {
 
 export default ClassMap;
 
-const itemStackTokens: IStackTokens = {
+export const mappedItemStackTokens: IStackTokens = {
   childrenGap: 5,
 };
-const legendStackTokens: IStackTokens = {
-  childrenGap: 5,
+
+export const mappedItemLegendStackTokens: IStackTokens = {
+  childrenGap: 3,
 };
-const itemTextStyles: Partial<ITextStyles> = {
+
+export const mappedItemTextStyles: Partial<ITextStyles> = {
   root: {
     fontSize: FontSizes.smallPlus,
   },
 };
-const legendStyles: IStackItemStyles = {
+
+export const mappedItemLegendStyles: IStackItemStyles = {
   root: {
     maxHeight: 150,
     overflowY: "auto",

--- a/src/pages/Explore/components/Map/components/LegendControl/legendTypes/ColorMap.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/legendTypes/ColorMap.tsx
@@ -14,7 +14,7 @@ import {
 } from "@fluentui/react";
 import * as qs from "query-string";
 
-import { rootColormapUrl } from "./helpers";
+import { rootColormapUrl } from "../helpers";
 import { ILegendConfig } from "pages/Explore/types";
 import { QsParamType } from "types";
 

--- a/src/pages/Explore/components/Map/components/LegendControl/legendTypes/Interval.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/legendTypes/Interval.tsx
@@ -1,0 +1,69 @@
+import {
+  Shimmer,
+  ShimmerElementType,
+  Stack,
+  StackItem,
+  Text,
+} from "@fluentui/react";
+import { ILegendConfig } from "pages/Explore/types";
+import * as qs from "query-string";
+import { FC } from "react";
+import { IntervalMap, useInterval } from "../helpers";
+import {
+  ColorSwatch,
+  mappedItemLegendStackTokens,
+  mappedItemLegendStyles,
+  mappedItemTextStyles,
+} from "./ClassMap";
+
+interface IntervalProps {
+  params: qs.ParsedQuery<string>;
+  legendConfig: ILegendConfig | undefined;
+}
+
+const Interval: FC<IntervalProps> = ({ params, legendConfig }) => {
+  const classmapName =
+    params.colormap_name && Array.isArray(params.colormap_name)
+      ? params.colormap_name[0]
+      : params.colormap_name;
+
+  const { isLoading, data: intervals } = useInterval(classmapName);
+
+  const def = classmapName ? intervals : JSON.parse(params.colormap as string);
+  const loading = isLoading && (
+    <Shimmer
+      shimmerElements={[{ type: ShimmerElementType.line, height: 20, width: 233 }]}
+    />
+  );
+
+  const labelScaleFactor = legendConfig?.scaleFactor ?? 0.0001;
+
+  return (
+    <StackItem styles={mappedItemLegendStyles} className="custom-overflow">
+      {loading}
+      <Stack tokens={mappedItemLegendStackTokens}>
+        {def && makeSwatches(def, labelScaleFactor)}
+      </Stack>
+    </StackItem>
+  );
+};
+
+export default Interval;
+
+const makeSwatches = (intervals: IntervalMap, scaleFactor: number = 1) => {
+  return intervals.map(([[min, max], rgba]) => {
+    const formattedMin = (min * scaleFactor).toLocaleString();
+    const formattedMax = (max * scaleFactor).toLocaleString();
+
+    return (
+      <StackItem key={`interval-${min}-${max}`}>
+        <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 5 }}>
+          <ColorSwatch color={rgba} />
+          <Text
+            styles={mappedItemTextStyles}
+          >{`${formattedMin} – ${formattedMax}`}</Text>
+        </Stack>
+      </StackItem>
+    );
+  });
+};

--- a/src/pages/Explore/components/controls/PriorityAttributes.tsx
+++ b/src/pages/Explore/components/controls/PriorityAttributes.tsx
@@ -13,7 +13,24 @@ interface PriorityAttributesProps {
 const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
   const theme = useTheme();
   const cloud = item.properties?.["eo:cloud_cover"];
-  const dt = item.properties?.datetime;
+
+  // Items typically have a datetime, if not, they'll have start_/end_datetime
+  const date = item.properties?.datetime;
+  const dateRange = [
+    item.properties?.start_datetime,
+    item.properties?.end_datetime,
+  ].filter(Boolean);
+  const hasRange = dateRange.length > 0;
+
+  const dtRangeTitle = hasRange && (
+    <span title="Acquired between">
+      {toUtcDateString(dateRange[0])} — {toUtcDateString(dateRange[1])}
+    </span>
+  );
+
+  const dtTitle = !hasRange && date && (
+    <span title="Acquisition date">{toUtcDateString(date)}</span>
+  );
 
   return (
     <Stack
@@ -26,7 +43,8 @@ const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
         },
       }}
     >
-      {dt && <span title="Acquisition date">{toUtcDateString(dt)}</span>}
+      {dtTitle}
+      {dtRangeTitle}
       <StackItem styles={{ root: { paddingRight: 8 } }}>
         {isNumber(cloud) && (
           <IconValue

--- a/src/pages/Explore/enums.ts
+++ b/src/pages/Explore/enums.ts
@@ -3,5 +3,6 @@
 export enum LegendTypes {
   classmap = "classmap",
   continuous = "continuous",
+  interval = "interval",
   none = "none",
 }

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -35,6 +35,7 @@ export interface ILegendConfig {
   labels?: string[];
   trimStart?: number;
   trimEnd?: number;
+  scaleFactor?: number;
 }
 
 export interface IMapInfo {


### PR DESCRIPTION
* Some items don't have datetime, instead representing a range of acquisition. Use this range as the priority attribute on item card headers.
* Supports a new legend type, `interval`, which is a discrete classmap with min/max ranges for each break. Includes support for a `scaleFactor` config option if the min/max labels (taken from the classmap definition) should have a scale applied to them before rendering. This is useful for non-unscaled raster values being used in the colormap definition.