### PR TITLE
Remove Landsat8 C2 L2 from all frontend components

### DIFF
--- a/etl/config/codefiles_urls.txt
+++ b/etl/config/codefiles_urls.txt
@@ -1,7 +1,5 @@
 https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/data/aster.ipynb
 https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/storage-docs/aster-storage.md
-https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/data/landsat-8.ipynb
-https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/storage-docs/landsat-8-storage.md
 https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/data/naip.ipynb
 https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/storage-docs/naip-storage.md
 https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/data/sentinel-2.ipynb
@@ -31,7 +29,6 @@ https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/storage-docs
 https://raw.githubusercontent.com/microsoft/AIforEarthDataSets/main/data/alos-dem.ipynb
 
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/aster-l1t/aster-l1t-example.ipynb
-https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/landsat-8-c2-l2/landsat-8-c2-l2-example.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/naip/naip-example.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/sentinel-2-l2a/sentinel-2-l2a-example.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/quickstarts/reading-stac-r.ipynb

--- a/src/config/datasets.yml
+++ b/src/config/datasets.yml
@@ -11,8 +11,11 @@
 # `category` attribute determines which header the dataset is included under in the
 # Explorer collection selector
 
+# `isHidden` attribute determines if the dataset is hidden in any frontend component, including
+# the Explorer.
+
 # `hideInExplorer` attribute determines if the dataset is hidden in the Explorer, even
-# if would otherwise be available
+# if would otherwise be available. It is still visible in the catalog.
 
 # To include a button on a tab to launch the notebook in Hub, add the following
 # config to the tab item. Assumes PlanetaryComputerExamples/main.
@@ -295,16 +298,7 @@ collections:
     headerImg: ./images/landsat-c2-l2-hero.png
 
   landsat-8-c2-l2:
-    category: Imagery
-    headerImg: ./images/landsat-hero.jpg
-    tabs:
-      - title: Example Notebook
-        src: landsat-8-c2-l2-example.html
-        launch: datasets/landsat-8-c2-l2/landsat-8-c2-l2-example.ipynb
-      - title: Blob Storage Notebook
-        src: landsat-8.html
-      - title: Storage Documentation
-        src: landsat-8-storage.html
+    isHidden: true
 
   modis-14A1-061:
     category: Fire

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,23 +3,24 @@ declare module "*.yml" {
   export default data;
 }
 
-interface launchConfig {
+interface LaunchConfig {
   repo: string;
   branch: string;
   filePath: string;
 }
-interface tabEntry {
+interface TabEntry {
   title: string;
   src: string;
   launch: string | lauchConfig;
 }
-interface datasetEntry {
+interface DatasetEntry {
   category: string;
   headerImg: string;
-  tabs: tabEntry[];
+  tabs: TabEntry[];
   hideInExplorer?: boolean;
+  isHidden: boolean;
 }
 declare module "config/datasets.yml" {
-  export const collections: Record<string, datasetEntry>;
+  export const collections: Record<string, DatasetEntry>;
   export const ai4e: any;
 }


### PR DESCRIPTION
Adds configuration options to exclude a dataset from the frontend.

All Landsat C2 L2 platforms are now included a in a single, new collection. The original collection will be maintained for backwards compatibility but is not being promoted on the site going forward.