### PR TITLE
Fixed `proj:projjson` rendering for item detail

### DIFF
--- a/src/utils/stac.js
+++ b/src/utils/stac.js
@@ -172,6 +172,10 @@ StacFields.Registry.addMetadataField("proj:wkt2", {
 StacFields.Registry.addMetadataField("proj:geometry", {
   formatter: value => <code>{JSON.stringify(value)}</code>,
 });
+StacFields.Registry.addMetadataField("proj:projjson", {
+  formatter: value => <code>{JSON.stringify(value)}</code>,
+});
+
 
 StacFields.Registry.addMetadataField("sat:orbit_state", {
   formatter: capitalize,


### PR DESCRIPTION
Currently, these don't render well.

![image](https://user-images.githubusercontent.com/1312546/162001974-5d7878a5-5587-4109-880b-67096e39d3ea.png)

Adding a snippet to make it render like `proj:geometry.`