### PR TITLE
Limit account request body size

### DIFF
--- a/api/survey/__init__.py
+++ b/api/survey/__init__.py
@@ -6,6 +6,8 @@ import azure.functions as func
 
 from .card import make_card
 
+MAX_SIZE = 8000  # 8kb
+
 
 def main(req: func.HttpRequest) -> func.HttpResponse:
 
@@ -15,6 +17,12 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     az_env = os.environ.get("AZURE_FUNCTIONS_ENVIRONMENT")
     signup_url = os.environ.get("SignupUrl")
     signup_token = os.environ.get("SignupToken")
+
+    # Prevent excessive request body size
+    payload_size = len(req.get_body())
+    if payload_size > MAX_SIZE:
+        logging.error(f"Request payload too large: {payload_size} bytes")
+        return func.HttpResponse("Request payload too large", status_code=413)
 
     try:
         req_body = req.get_json()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     working_dir: /usr/src
     ports:
       - "7071:7071"
+      - "8000:8000"
     volumes:
       - ./api:/usr/src
     networks:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pc-datacatalog",
   "version": "2022.1.1",
   "private": true,
-  "proxy": "http://localhost:7071/",
+  "proxy": "http://api:7071/",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "@craco/craco": "^6.4.3",

--- a/src/components/forms/FormCheckbox.js
+++ b/src/components/forms/FormCheckbox.js
@@ -1,7 +1,7 @@
 import { Checkbox } from "@fluentui/react";
 import { useFormikContext } from "formik";
 
-const FormCheckbox = ({ name, label, placeholder, required = false }) => {
+const FormCheckbox = ({ name, label, placeholder = null, required = false }) => {
   const { values, touched, errors, setFieldValue } = useFormikContext();
 
   return (

--- a/src/components/forms/FormInput.js
+++ b/src/components/forms/FormInput.js
@@ -22,6 +22,7 @@ const FormInput = ({
       value={values[name]}
       errorMessage={touched[name] && errors[name]}
       onChange={handleChange}
+      maxLength={multiline ? 1000 : 255}
     />
   );
 };

--- a/src/pages/AccountSurvey.tsx
+++ b/src/pages/AccountSurvey.tsx
@@ -21,13 +21,12 @@ import FormCheckbox from "../components/forms/FormCheckbox";
 import DefaultBanner from "../components/DefaultBanner";
 import NewTabLink from "../components/controls/NewTabLink";
 
-import { languageOptions, industryOptions } from "../config/account.yml";
-import countries from "../config/countries.yml";
+import options from "config/account.yml";
+import countries from "config/countries.yml";
 
 import { marginVStyle } from "../styles";
 import { ScrollToTopOnMount } from "../components/ScrollToTopOnMount";
 
-const rowProps = { horizontal: true, verticalAlign: "center" };
 const stackTokens = {
   spinnerStack: {
     childrenGap: 20,
@@ -36,18 +35,17 @@ const stackTokens = {
 
 const AccountSurvey = () => {
   const navigate = useNavigate();
-  const mutation = useMutation(survey => axios.post("./api/survey", survey));
+  const mutation = useMutation((survey: Record<string, any>) =>
+    axios.post("./api/survey", survey)
+  );
 
-  const handleSubmit = survey => {
+  const handleSubmit = (survey: Record<string, any>) => {
     mutation.mutate(survey);
   };
 
   const validationSchema = yup.object({
-    email: yup
-      .string("Enter your email")
-      .email("Enter a valid email")
-      .required("Email is required"),
-    name: yup.string("Enter your full name").required("Your name is required"),
+    email: yup.string().email("Enter a valid email").required("Email is required"),
+    name: yup.string().required("Your name is required"),
     affiliation: yup.string(),
     industry: yup.string(),
     languages: yup.array(),
@@ -110,12 +108,16 @@ const AccountSurvey = () => {
             label="Affiliated Organization"
             placeholder="Company, institution, university, etc."
           />
-          <FormSelect name="industry" label="Sector" options={industryOptions} />
+          <FormSelect
+            name="industry"
+            label="Sector"
+            options={options.industryOptions}
+          />
           <FormSelect
             multiSelect
             name="languages"
             label="Primary programming languages"
-            options={languageOptions}
+            options={options.languageOptions}
           />
           <FormSelect
             name="country"
@@ -134,7 +136,11 @@ const AccountSurvey = () => {
           />
           <FormCheckbox name="terms" label={tosLabel} required={true} />
         </Stack>
-        <Stack {...rowProps} tokens={stackTokens.spinnerStack}>
+        <Stack
+          horizontal={true}
+          verticalAlign="center"
+          tokens={stackTokens.spinnerStack}
+        >
           <PrimaryButton
             disabled={mutation.isLoading}
             type="submit"


### PR DESCRIPTION
The Azure http runtime places a limit of 100MB on request sizes, which
risks tying up upstream resources went processing maliciously large payloads.
This size doesn't appear to be lowered, so precautions were put in place to limit
the extent of processing done on large payload sizes.

Places a modest limit on the size of text allowed in the form input
fields for account request, so the form cannot be used to submit large
payloads. Additionally, the Azure Function checks the size of the
request payload and rejects it prior to further processing if it exceeds
a reasonable size for the expected content.

The source file was converted to Typescript as part of ongoing
maintenance.