### PR TITLE
Pinned layers edit state is preserved in URL state

### DIFF
--- a/cypress/integration/explorer/url_state_spec.js
+++ b/cypress/integration/explorer/url_state_spec.js
@@ -16,7 +16,12 @@ describe("URL state is loaded to Explorer", () => {
     );
     cy.intercept("/api/stac/v1/search").as("getS2search");
 
-    cy.visit("/explore?d=sentinel-2-l2a");
+    cy.visit({
+      url: "/explore",
+      qs: {
+        d: "sentinel-2-l2a",
+      },
+    });
 
     cy.wait(["@getS2", "@getS2mosaic"]);
 
@@ -41,6 +46,7 @@ describe("URL state is loaded to Explorer", () => {
         d: "sentinel-2-l2a",
         m: "Dec – Feb, 2022 (low cloud)",
         r: "Color infrared",
+        ae: "0",
       },
     });
 
@@ -96,6 +102,7 @@ describe("URL state is loaded to Explorer", () => {
         s: "true::100::true||true::100::true",
         m: "Most recent||All years",
         r: "Elevation (terrain)||Aboveground Biomass (tonnes)",
+        ae: "1",
       },
     });
 
@@ -108,5 +115,7 @@ describe("URL state is loaded to Explorer", () => {
       .should("be.visible")
       .and("contain", "Chloris Biomass")
       .and("contain", "NASADEM");
+
+    cy.getBySel("collection-selector").contains("Chloris Biomass");
   });
 });

--- a/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
@@ -10,6 +10,7 @@ export const QS_COLLECTION_KEY = "d";
 export const QS_MOSAIC_KEY = "m";
 export const QS_RENDER_KEY = "r";
 export const QS_SETTINGS_KEY = "s";
+export const QS_ACTIVE_EDIT_KEY = "ae";
 export const QS_VERSION_KEY = "v";
 export const QS_V1_CUSTOM_KEY = "q";
 
@@ -18,7 +19,9 @@ export const QS_V1_CUSTOM_KEY = "q";
  * sharing and recreating the app state
  */
 export const useUrlStateV2 = () => {
-  const { layers, layerOrder } = useExploreSelector(s => s.mosaic);
+  const { layers, layerOrder, currentEditingLayerId } = useExploreSelector(
+    s => s.mosaic
+  );
   const orderedLayers = layerOrder.map(id => layers[id]);
 
   const setRenderQs = useCallback((ol: ILayerState[]) => {
@@ -58,15 +61,30 @@ export const useUrlStateV2 = () => {
     updateQueryStringParam(QS_SETTINGS_KEY, settings);
   }, []);
 
+  const setLayerEditingQs = useCallback(
+    (ol: ILayerState[]) => {
+      // Since the layer id is generated when added to the map, specify the index
+      // of the ordered layer that is being edited so it can be restored when the
+      // url is reloaded
+      const idx = currentEditingLayerId
+        ? ol.findIndex(l => l.layerId === currentEditingLayerId).toString()
+        : "";
+      updateQueryStringParam(QS_ACTIVE_EDIT_KEY, idx);
+    },
+    [currentEditingLayerId]
+  );
+
   useEffect(() => {
     setCollectionQs(orderedLayers);
     setMosiacQs(orderedLayers);
     setRenderQs(orderedLayers);
     setLayerSettingsQs(orderedLayers);
+    setLayerEditingQs(orderedLayers);
   }, [
     layers,
     orderedLayers,
     setCollectionQs,
+    setLayerEditingQs,
     setLayerSettingsQs,
     setMosiacQs,
     setRenderQs,


### PR DESCRIPTION
Previous implementation assumed that only unpinned layers could be in an
active edit state, but pinned layers can also now be re-edited and that
state is encoded in URL state now.