### PR TITLE
Use new interval legend endpoint

### DIFF
--- a/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
+++ b/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
@@ -10,6 +10,7 @@ import { DATA_URL } from "utils/constants";
 
 export const rootColormapUrl = `${DATA_URL}/legend/colormap`;
 export const rootClassmapUrl = `${DATA_URL}/legend/classmap`;
+export const rootIntervalUrl = `${DATA_URL}/legend/interval`;
 
 // [[[min, max], [r,g,b,a]],...]
 export type IntervalMap = [[number, number], [number, number, number, number]][];
@@ -83,6 +84,6 @@ const getIntervalClassmapByName = async (
   const [, classmapName] = queryParam.queryKey;
 
   return await (
-    await axios.get(`${rootClassmapUrl}/${classmapName}`)
+    await axios.get(`${rootIntervalUrl}/${classmapName}`)
   ).data;
 };

--- a/src/pages/Explore/components/Map/components/LegendControl/legendTypes/Interval.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/legendTypes/Interval.tsx
@@ -21,6 +21,8 @@ interface IntervalProps {
   legendConfig: ILegendConfig | undefined;
 }
 
+const DEFAULT_SCALE_FACTOR = 1;
+
 const Interval: FC<IntervalProps> = ({ params, legendConfig }) => {
   const classmapName =
     params.colormap_name && Array.isArray(params.colormap_name)
@@ -38,7 +40,7 @@ const Interval: FC<IntervalProps> = ({ params, legendConfig }) => {
     />
   );
 
-  const labelScaleFactor = legendConfig?.scaleFactor ?? 0.0001;
+  const labelScaleFactor = legendConfig?.scaleFactor ?? DEFAULT_SCALE_FACTOR;
 
   return (
     <StackItem styles={mappedItemLegendStyles} className="custom-overflow">
@@ -52,7 +54,10 @@ const Interval: FC<IntervalProps> = ({ params, legendConfig }) => {
 
 export default Interval;
 
-const makeSwatches = (intervals: IntervalMap, scaleFactor: number = 1) => {
+const makeSwatches = (
+  intervals: IntervalMap,
+  scaleFactor: number = DEFAULT_SCALE_FACTOR
+) => {
   return intervals.map(([[min, max], rgba]) => {
     const formattedMin = (min * scaleFactor).toLocaleString();
     const formattedMax = (max * scaleFactor).toLocaleString();


### PR DESCRIPTION
Interval legend definitions use a different mapping type from classmaps. A forthcoming API release will include a new interval-specific endpoint.