### PR TITLE
Pass trim arguments to legend mapping endpoints

### DIFF
--- a/src/pages/Explore/components/Map/components/LegendControl/Legend.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/Legend.tsx
@@ -98,7 +98,13 @@ const getLegendType = (
   if (legendConfig) {
     switch (legendConfig.type) {
       case LegendTypes.classmap:
-        return <ClassMap params={params} collection={collection} />;
+        return (
+          <ClassMap
+            params={params}
+            collection={collection}
+            legendConfig={legendConfig}
+          />
+        );
       case LegendTypes.continuous:
         return <ColorMap params={params} legendConfig={legendConfig} />;
       case LegendTypes.interval:
@@ -115,7 +121,13 @@ const getLegendType = (
   }
 
   if (hasClassmapValues(collection, params.assets)) {
-    return <ClassMap params={params} collection={collection} />;
+    return (
+      <ClassMap
+        params={params}
+        collection={collection}
+        legendConfig={legendConfig}
+      />
+    );
   }
   return null;
 };

--- a/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
+++ b/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
+import { ILegendConfig } from "pages/Explore/types";
 import { QueryFunctionContext, useQuery } from "react-query";
 import { QsParamType } from "types";
+import * as qs from "query-string";
 import {
   ClassificationExtClasses,
   FileExtValues,
@@ -44,22 +46,12 @@ export const fileValuesToClassificationClasses = (
   });
 };
 
-export const useClassmap = (classmapName: string | null) => {
-  return useQuery(["classmap", classmapName], getClassmapByName, {
+export const useClassmap = (classmapName: string | null, config?: ILegendConfig) => {
+  return useQuery(["classmap", classmapName, config], getLegendMappingByName, {
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     enabled: Boolean(classmapName),
   });
-};
-
-const getClassmapByName = async (
-  queryParam: QueryFunctionContext<["classmap" | "interval", string | null]>
-): Promise<ClassMap> => {
-  const [, classmapName] = queryParam.queryKey;
-
-  return await (
-    await axios.get(`${rootClassmapUrl}/${classmapName}`)
-  ).data;
 };
 
 export const getClassNameByValue = (
@@ -70,20 +62,32 @@ export const getClassNameByValue = (
   return matchingValue?.description;
 };
 
-export const useInterval = (intervalName: string | null) => {
-  return useQuery(["interval", intervalName], getIntervalClassmapByName, {
+export const useInterval = (intervalName: string | null, config?: ILegendConfig) => {
+  return useQuery(["interval", intervalName, config], getLegendMappingByName, {
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     enabled: Boolean(intervalName),
   });
 };
 
-const getIntervalClassmapByName = async (
-  queryParam: QueryFunctionContext<["classmap" | "interval", string | null]>
-): Promise<IntervalMap> => {
-  const [, classmapName] = queryParam.queryKey;
+const getLegendMappingByName = async (
+  queryParam: QueryFunctionContext<
+    ["classmap" | "interval", string | null, ILegendConfig | undefined]
+  >
+): Promise<ClassMap> => {
+  const [legendType, classmapName, config] = queryParam.queryKey;
+
+  const qsConfig = config
+    ? "?" +
+      qs.stringify(
+        { trim_start: config.trimStart, trim_end: config.trimEnd },
+        { skipNull: true }
+      )
+    : "";
+
+  const rootUrl = legendType === "classmap" ? rootClassmapUrl : rootIntervalUrl;
 
   return await (
-    await axios.get(`${rootIntervalUrl}/${classmapName}`)
+    await axios.get(`${rootUrl}/${classmapName}${qsConfig}`)
   ).data;
 };

--- a/src/pages/Explore/components/Map/components/LegendControl/legendTypes/ClassMap.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/legendTypes/ClassMap.tsx
@@ -10,6 +10,7 @@ import {
   StackItem,
   Text,
 } from "@fluentui/react";
+import { ILegendConfig } from "pages/Explore/types";
 import * as qs from "query-string";
 import { IStacCollection } from "types/stac";
 import {
@@ -21,14 +22,15 @@ import {
 interface ClassMapProps {
   params: qs.ParsedQuery<string>;
   collection: IStacCollection | null;
+  legendConfig?: ILegendConfig;
 }
 
-const ClassMap = ({ params, collection }: ClassMapProps) => {
+const ClassMap = ({ params, collection, legendConfig }: ClassMapProps) => {
   const classmapName = Array.isArray(params.colormap_name)
     ? params.colormap_name[0]
     : params.colormap_name;
 
-  const { isLoading, data: classes } = useClassmap(classmapName);
+  const { isLoading, data: classes } = useClassmap(classmapName, legendConfig);
   const definition = classmapName
     ? classes
     : params.colormap && JSON.parse(params.colormap as string);

--- a/src/pages/Explore/components/Map/components/LegendControl/legendTypes/Interval.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/legendTypes/Interval.tsx
@@ -18,7 +18,7 @@ import {
 
 interface IntervalProps {
   params: qs.ParsedQuery<string>;
-  legendConfig: ILegendConfig | undefined;
+  legendConfig?: ILegendConfig;
 }
 
 const DEFAULT_SCALE_FACTOR = 1;
@@ -29,7 +29,7 @@ const Interval: FC<IntervalProps> = ({ params, legendConfig }) => {
       ? params.colormap_name[0]
       : params.colormap_name;
 
-  const { isLoading, data: intervals } = useInterval(classmapName);
+  const { isLoading, data: intervals } = useInterval(classmapName, legendConfig);
 
   const definition = classmapName
     ? intervals


### PR DESCRIPTION
Trimming start/end of classmap and interval legend types was supported but the arguments were not passed to the API. These are now supplied, and the request mechanism is consolidated for the two types.