### PR TITLE
Allow conditional rendering options

### DIFF
--- a/src/pages/Explore/components/Sidebar/selectors/RenderOptionsSelector.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/RenderOptionsSelector.tsx
@@ -5,6 +5,8 @@ import { useCollectionMosaicInfo } from "../../../utils/hooks";
 import { selectCurrentMosaic, setRenderOption } from "../../../state/mosaicSlice";
 import { useExploreDispatch, useExploreSelector } from "../../../state/hooks";
 import StateSelector from "./StateSelector";
+import useCqlPropertyMatcher from "./hooks/useCqlPropertyMatcher";
+import { every } from "lodash-es";
 
 const RenderOptionsSelector = () => {
   const dispatch = useExploreDispatch();
@@ -20,14 +22,34 @@ const RenderOptionsSelector = () => {
 
   const renderers = mosaicInfo?.renderOptions ?? [];
 
+  const matcher = useCqlPropertyMatcher();
   const options = renderers.map((renderer): IDropdownOption => {
-    return { key: renderer.name, text: renderer.name };
+    const enabled = every(
+      renderer.conditions?.map(condition =>
+        matcher(condition.property, condition.value)
+      )
+    );
+    return { key: renderer.name, text: renderer.name, disabled: !enabled };
   });
 
   const getOptionByName = (key: string | number) => {
     return mosaicInfo?.renderOptions?.find(mosaic => mosaic.name === key);
   };
 
+  // If the currently selected option is now disabled, move to the first
+  // non-disabled option
+  const enabledSelectedKey = options.find(
+    option => option.key === renderOption?.name
+  )?.disabled
+    ? options.find(option => !option.disabled)?.key
+    : renderOption?.name;
+
+  if (enabledSelectedKey !== renderOption?.name) {
+    if (enabledSelectedKey) {
+      const newOption = getOptionByName(enabledSelectedKey);
+      newOption && dispatch(setRenderOption(newOption));
+    }
+  }
   return (
     <StateSelector
       title="Select a rendering option"

--- a/src/pages/Explore/components/Sidebar/selectors/hooks/useCqlPropertyMatcher.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/hooks/useCqlPropertyMatcher.tsx
@@ -1,0 +1,30 @@
+import { useExploreSelector } from "pages/Explore/state/hooks";
+import { selectCurrentCql } from "pages/Explore/state/mosaicSlice";
+import { CqlExpressionParser } from "pages/Explore/utils/cql";
+import { CqlExpression } from "pages/Explore/utils/cql/types";
+
+// Test the current mosaic cql to determine if a property/value combo is present.
+// Assumes only a single level of nesting, as that is what the Explorer can produce.
+const useCqlPropertyMatcher = () => {
+  const cql = useExploreSelector(selectCurrentCql);
+
+  return (property: string, value: string | number) => {
+    const expression = cql
+      .map((exp: CqlExpression) => new CqlExpressionParser(exp))
+      .find(parser => parser.property === property);
+
+    if (!expression) {
+      return false;
+    }
+
+    const inclusiveOperators = ["=", ">", ">=", "in", "between", "like"];
+    const values = Array.isArray(expression.value)
+      ? expression.value
+      : [expression.value];
+    return (
+      values.includes(value) && inclusiveOperators.includes(expression.operator)
+    );
+  };
+};
+
+export default useCqlPropertyMatcher;

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -22,12 +22,17 @@ export interface IMosaic {
   searchId?: string | null;
 }
 
+export interface IMosaicRenderOptionCondition {
+  property: string;
+  value: any;
+}
 export interface IMosaicRenderOption {
   name: string;
   description: string;
   options: string;
   minZoom: number | undefined;
   legend: ILegendConfig | undefined;
+  conditions?: IMosaicRenderOptionCondition[];
 }
 
 export interface ILegendConfig {


### PR DESCRIPTION
Rendering options can be enabled based on the presence of a
property/value combination in the selected mosaic CQL.