### PR TITLE
Add array field

### DIFF
--- a/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
@@ -67,9 +67,11 @@ export const useUrlStateV2 = () => {
       // of the ordered layer that is being edited so it can be restored when the
       // url is reloaded
       const idx = currentEditingLayerId
-        ? ol.findIndex(l => l.layerId === currentEditingLayerId).toString()
-        : "";
-      updateQueryStringParam(QS_ACTIVE_EDIT_KEY, idx);
+        ? ol.findIndex(l => l.layerId === currentEditingLayerId)
+        : -1;
+
+      const newVal = idx >= 0 ? idx.toString() : "";
+      updateQueryStringParam(QS_ACTIVE_EDIT_KEY, newVal);
     },
     [currentEditingLayerId]
   );

--- a/src/pages/Explore/components/query/EnumArrayField/EnumArrayField.test.tsx
+++ b/src/pages/Explore/components/query/EnumArrayField/EnumArrayField.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "pages/Explore/utils/testUtils";
+
+import { EnumArrayField } from "./EnumArrayField";
+import { CqlExpressionParser } from "pages/Explore/utils/cql";
+import { CqlEqualExpression } from "pages/Explore/utils/cql/types";
+import { JSONSchema } from "@apidevtools/json-schema-ref-parser";
+
+const queryable: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  properties: {
+    "sar:polarization": {
+      title: "Polarization",
+      type: "array",
+      enum: [["HH,HV"], ["VV, VH"]],
+    },
+  },
+};
+
+const eq: CqlEqualExpression<string[]> = {
+  op: "=",
+  args: [{ property: "sar:polarization" }, ["HH", "HV"]],
+};
+
+test("it displays correct title and formatted value for EQ", async () => {
+  const field = new CqlExpressionParser<string[]>(eq, queryable);
+  render(<EnumArrayField field={field} />);
+
+  const label = screen.getByText("Polarization");
+  expect(label).toBeInTheDocument();
+
+  const value = screen.getByText("[HH,HV]");
+  expect(value).toBeInTheDocument();
+});

--- a/src/pages/Explore/components/query/EnumArrayField/EnumArrayField.tsx
+++ b/src/pages/Explore/components/query/EnumArrayField/EnumArrayField.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { JSONSchema } from "@apidevtools/json-schema-ref-parser";
+import {
+  Dropdown,
+  getTheme,
+  IDropdownOption,
+  IDropdownStyles,
+} from "@fluentui/react";
+import { CqlExpressionParser } from "pages/Explore/utils/cql";
+import {
+  renderSegmentedPlaceholder,
+  renderSegmentedTitle,
+} from "pages/Explore/utils/dropdownRenderers";
+import { useExploreDispatch } from "pages/Explore/state/hooks";
+import { setCustomCqlExpressions } from "pages/Explore/state/mosaicSlice";
+import { CqlEqualExpression } from "pages/Explore/utils/cql/types";
+import { stacFormatter } from "utils/stac";
+
+type EnumFieldProps = {
+  field: CqlExpressionParser<string[]>;
+};
+
+export const EnumArrayField = ({ field }: EnumFieldProps) => {
+  const dispatch = useExploreDispatch();
+  const [selectedKey, setSelectedKey] = useState<string[]>(field.value as string[]);
+
+  if (!field.fieldSchema) return null;
+
+  const handleChange = (
+    _: React.FormEvent<HTMLDivElement>,
+    item: IDropdownOption | undefined
+  ): void => {
+    if (item) {
+      console.log(item.key);
+      const key = (item.key as string).split(",");
+      setSelectedKey(key);
+      handleUpdate(key);
+    }
+  };
+
+  const handleUpdate = (key: string[]) => {
+    const cql = parseKeysToCql(key, field);
+    if (cql) {
+      dispatch(setCustomCqlExpressions(cql));
+    }
+  };
+
+  const title = field.fieldSchema.title || field.property;
+  const options = enumToOptions(field.fieldSchema.enum, field.property);
+
+  return (
+    <Dropdown
+      options={options}
+      selectedKey={selectedKey.join(",")}
+      ariaLabel={`${title} dropdown selector`}
+      onRenderTitle={renderSegmentedTitle(title)}
+      onRenderPlaceholder={renderSegmentedPlaceholder(title, "Include all")}
+      onChange={handleChange}
+      styles={dropdownStyles}
+    />
+  );
+};
+
+const enumToOptions = (
+  enumValues: JSONSchema["enum"] = [],
+  property: string
+): IDropdownOption[] => {
+  return enumValues.map(value => {
+    const display = stacFormatter.format(String(value), property);
+    const v = (value as string[]) || [];
+    return { key: v.join(","), text: `[${display}]` };
+  });
+};
+
+const parseKeysToCql = (
+  selectedKey: string[],
+  field: CqlExpressionParser<string[]>
+): CqlEqualExpression<string[]> | null => {
+  return { op: "=", args: [{ property: field.property }, selectedKey] };
+};
+
+const theme = getTheme();
+const dropdownStyles: Partial<IDropdownStyles> = {
+  title: {
+    borderColor: theme.palette.neutralTertiaryAlt,
+    ":hover": {
+      borderColor: theme.palette.neutralTertiary + " !important",
+    },
+  },
+};

--- a/src/pages/Explore/components/query/EnumArrayField/EnumArrayField.tsx
+++ b/src/pages/Explore/components/query/EnumArrayField/EnumArrayField.tsx
@@ -31,7 +31,6 @@ export const EnumArrayField = ({ field }: EnumFieldProps) => {
     item: IDropdownOption | undefined
   ): void => {
     if (item) {
-      console.log(item.key);
       const key = (item.key as string).split(",");
       setSelectedKey(key);
       handleUpdate(key);

--- a/src/pages/Explore/components/query/EnumArrayField/index.ts
+++ b/src/pages/Explore/components/query/EnumArrayField/index.ts
@@ -1,0 +1,1 @@
+export * from "./EnumArrayField";

--- a/src/pages/Explore/state/inititalStateHelper.ts
+++ b/src/pages/Explore/state/inititalStateHelper.ts
@@ -168,7 +168,7 @@ const loadMosaicStateV2 = async (
         exp => new CqlExpressionParser(exp).property !== "collection"
       );
 
-      const query = { ...mosaic, searchId, cqlClean };
+      const query = { ...mosaic, searchId, cql: cqlClean };
 
       // Fetch the minzoom from the tilejson endpoint for this collection/renderOption
       const minZoom = (await fetchTileJson(query, renderOption, collection)).minzoom;

--- a/src/pages/Explore/state/inititalStateHelper.ts
+++ b/src/pages/Explore/state/inititalStateHelper.ts
@@ -16,6 +16,7 @@ import {
 } from "../components/Sidebar/selectors/hooks/useUrlStateV2";
 import { ILayerState, IMosaic, IMosaicInfo } from "../types";
 import { updateQueryStringParam } from "../utils";
+import { CqlExpressionParser } from "../utils/cql";
 import {
   fetchCollection,
   fetchCollectionMosaicInfo,
@@ -161,7 +162,13 @@ const loadMosaicStateV2 = async (
         ? (await fetchSearchIdMetadata(searchId)).search.search.filter.args
         : mosaic.cql;
 
-      const query = { ...mosaic, searchId, cql };
+      // The registered cql will have had the collection id property added
+      // which we don't need. It's stored directly on the state.
+      const cqlClean = cql.filter(
+        exp => new CqlExpressionParser(exp).property !== "collection"
+      );
+
+      const query = { ...mosaic, searchId, cqlClean };
 
       // Fetch the minzoom from the tilejson endpoint for this collection/renderOption
       const minZoom = (await fetchTileJson(query, renderOption, collection)).minzoom;

--- a/src/pages/Explore/utils/cql/CqlExpressionParser.ts
+++ b/src/pages/Explore/utils/cql/CqlExpressionParser.ts
@@ -13,7 +13,7 @@ import {
 } from "./types";
 import { CQL_PROP_IDX, CQL_VALS_IDX } from "../constants";
 
-export class CqlExpressionParser<T extends string | number> {
+export class CqlExpressionParser<T extends string | number | string[]> {
   readonly exp: CqlExpression;
   readonly operator: CqlOperator;
   readonly property: string;

--- a/src/pages/Explore/utils/cql/helpers/formFields.tsx
+++ b/src/pages/Explore/utils/cql/helpers/formFields.tsx
@@ -3,12 +3,20 @@ import { EnumField } from "pages/Explore/components/query/EnumField";
 import { RangeField } from "pages/Explore/components/query/RangeField";
 import { TextNumberField } from "pages/Explore/components/query/TextNumberField/TextNumberField";
 import { TextStringField } from "pages/Explore/components/query/TextStringField";
+import { EnumArrayField } from "pages/Explore/components/query/EnumArrayField";
 
-export const getControlForField = (field: CqlExpressionParser<string | number>) => {
+export const getControlForField = (
+  field: CqlExpressionParser<string | number | string[]>
+) => {
   const schemaType = field.fieldSchema?.type;
   if (!schemaType) return null;
 
   switch (schemaType) {
+    case "array":
+      if (fieldSchemaIsEnum(field)) {
+        return getArrayControl(field as CqlExpressionParser<string[]>);
+      }
+      return null;
     case "string":
       if (fieldSchemaIsEnum(field)) {
         return getEnumControl(field as CqlExpressionParser<string>);
@@ -50,6 +58,12 @@ const getEnumControl = (field: CqlExpressionParser<string>) => {
   return <EnumField field={field} key={`enumcontrol-${field.property}`} />;
 };
 
-const fieldSchemaIsEnum = (field: CqlExpressionParser<string | number>) => {
+const getArrayControl = (field: CqlExpressionParser<string[]>) => {
+  return <EnumArrayField key={`arraycontrol-${field.property}`} field={field} />;
+};
+
+const fieldSchemaIsEnum = (
+  field: CqlExpressionParser<string | number | string[]>
+) => {
   return field.fieldSchema?.enum !== undefined;
 };

--- a/src/pages/Explore/utils/cql/helpers/index.ts
+++ b/src/pages/Explore/utils/cql/helpers/index.ts
@@ -48,6 +48,9 @@ export const makeDefaultCqlExpression = (
     case "number":
     case "integer":
       return defaultNumberCql(property, fieldSchema);
+    case "array":
+      const defaultValue = fieldSchema?.enum ? fieldSchema.enum[0] : [];
+      return { op: "=", args: [{ property: property }, defaultValue] };
     default:
       throw new Error(`Unsupported field type: ${fieldSchema.type}`);
   }

--- a/src/pages/Explore/utils/index.ts
+++ b/src/pages/Explore/utils/index.ts
@@ -1,5 +1,6 @@
 import { centerKey, zoomKey } from "../components/Map/hooks/useUrlState";
 import {
+  QS_ACTIVE_EDIT_KEY,
   QS_COLLECTION_KEY,
   QS_MOSAIC_KEY,
   QS_RENDER_KEY,
@@ -12,8 +13,9 @@ export const resetMosaicQueryStringState = () => {
     QS_COLLECTION_KEY,
     QS_MOSAIC_KEY,
     QS_RENDER_KEY,
-    QS_V1_CUSTOM_KEY,
+    QS_ACTIVE_EDIT_KEY,
     QS_VERSION_KEY,
+    QS_V1_CUSTOM_KEY,
   ].map(key => updateQueryStringParam(key, ""));
 };
 


### PR DESCRIPTION
New advanced filter type for array's which are currently assumed to all
be enum types. Array operators are not fully supported by pgstac, but a
workaround exists for single arrays and = operators, so this control is
for single-select only.