### PR TITLE
Allow optional grouping on Catalog2

### DIFF
--- a/src/config/datasetGroups.yml
+++ b/src/config/datasetGroups.yml
@@ -1,5 +1,7 @@
 # Metadata for a "group" page, which consolidates related collections.
-# `description` property accepts markdown
+
+# See type GroupEntry for properties.
+# Note: the `description` property accepts markdown
 
 3dep-lidar:
   title: USGS 3DEP Lidar Collection
@@ -22,6 +24,7 @@
     thumbnail:
       href: https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/3dep-lidar-copc-thumbnail.png
   keywords: [USGS, 3DEP, Elevation, Lidar, Point Cloud]
+  groupOnCatalog: false
 
 daymet:
   title: Daymet Collection
@@ -65,6 +68,7 @@ copernicus-dem:
     thumbnail:
       href: https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/cop-dem.png
   keywords: [Copernicus, DEM, DSM, elevation]
+  groupOnCatalog: false
 
 io-land-cover:
   title: 10 meter Land Cover
@@ -87,6 +91,7 @@ io-land-cover:
     thumbnail:
       href: https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/io-lulc.png
   keywords: [Global, Land Cover, Land Use, Sentinel]
+  groupOnCatalog: false
 
 gnatsgo:
   title: gNATSGO Soil Database
@@ -169,6 +174,7 @@ modis:
       Temperature,
       Land Cover,
     ]
+  groupOnCatalog: false
 
 landsat:
   title: Landsat Collection
@@ -210,6 +216,7 @@ landsat:
       "Reflectance",
       "Temperature",
     ]
+  groupOnCatalog: false
 
 planet-nicfi:
   title: Planet-NICFI Collection

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -53,6 +53,10 @@ interface DatasetGroup {
     };
   };
   keywords: string[];
+
+  // Should group members be categorized on the catalog page?
+  // Defaults to true.
+  groupOnCatalog?: boolean;
 }
 
 declare module "config/datasetGroups.yml" {

--- a/src/pages/Catalog2/Catalog.CollectionList.tsx
+++ b/src/pages/Catalog2/Catalog.CollectionList.tsx
@@ -38,7 +38,8 @@ export const CatalogCollectionList: React.FC<CatalogCollectionListProps> = ({
     data?.collections,
     storageCollectionConfig,
     isLoading,
-    collectionConfig
+    collectionConfig,
+    groupConfig
   );
   const sortedKeys = Object.keys(categorizedCollections).sort();
 
@@ -93,12 +94,7 @@ const getFeaturedDatasets = (
 ): IStacCollection[] => {
   const featured = featuredDatasetIds.map(datasetId => {
     if (datasetGroups[datasetId]) {
-      // Construct a minimal StacCollection from the dataset details
-      const { short_description, description, ...group } = datasetGroups[datasetId];
-      return Object.assign({}, group, {
-        "msft:short_description": datasetGroups[datasetId].short_description,
-        id: GROUP_PREFIX + datasetId,
-      });
+      return groupToPcCollection(datasetId, datasetGroups[datasetId]);
     }
     return collections?.find(collection => collection.id === datasetId) || null;
   });
@@ -110,7 +106,8 @@ const getCategorizedCollections = (
   collections: IStacCollection[] | undefined,
   nonApiCollections: Record<string, StorageDatasetEntry>,
   isLoading: boolean,
-  collectionConfig: Record<string, DatasetEntry>
+  collectionConfig: Record<string, DatasetEntry>,
+  groupConfig: Record<string, DatasetGroup>
 ): Record<string, IPcCollection[]> => {
   const groupedCollections: Record<string, IPcCollection[]> = {};
   // If collections have loaded, group them by category
@@ -120,10 +117,21 @@ const getCategorizedCollections = (
       if (!groupedCollections[category]) {
         groupedCollections[category] = [];
       }
-      groupedCollections[category].push(collection);
+
+      const groupId = collection["msft:group_id"];
+      const group = groupId ? groupConfig[groupId] : null;
+      if (groupId && group && group?.groupOnCatalog !== false) {
+        if (
+          !groupedCollections[category].find(c => c.id === GROUP_PREFIX + groupId)
+        ) {
+          groupedCollections[category].push(groupToPcCollection(groupId, group));
+        }
+      } else {
+        groupedCollections[category].push(collection);
+      }
     });
 
-    // Group the non-api collections as well
+    // Categorize the non-api collections as well
     Object.entries(nonApiCollections).forEach(([id, nonApiCollection]) => {
       const category = nonApiCollection.category || "Other";
       if (!groupedCollections[category]) {
@@ -143,6 +151,18 @@ const getCategorizedCollections = (
   }
 
   return groupedCollections;
+};
+
+const groupToPcCollection = (
+  groupId: string,
+  datasetGroup: DatasetGroup
+): IPcCollection => {
+  // Construct a minimal StacCollection from the dataset details
+  const { short_description, ...group } = datasetGroup;
+  return Object.assign({}, group, {
+    "msft:short_description": datasetGroup.short_description,
+    id: GROUP_PREFIX + groupId,
+  });
 };
 
 const headerStyle: React.CSSProperties = {

--- a/src/pages/Catalog2/Catalog.CollectionList.tsx
+++ b/src/pages/Catalog2/Catalog.CollectionList.tsx
@@ -53,12 +53,21 @@ export const CatalogCollectionList: React.FC<CatalogCollectionListProps> = ({
     const collections = categorizedCollections[category];
     const sortedCollections = sortBy(collections, "title");
 
+    // If loading, show placeholder shimmers per category. Featured category
+    // might have a mix of loading/existing, but we can determine how many shimmers
+    // are needed in addition to what is loaded
     const items =
       isEmpty(collections) && isLoading ? (
         getCollectionShimmers(3)
       ) : (
-        <List items={sortedCollections} onRenderCell={handleCellRender} />
+        <>
+          <List items={sortedCollections} onRenderCell={handleCellRender} />
+          {isLoading &&
+            category === "Featured" &&
+            getCollectionShimmers(featuredIds.length - sortedCollections.length)}
+        </>
       );
+
     return (
       <Stack
         key={`category-${category}`}

--- a/src/pages/Catalog2/Catalog.CollectionShimmer.tsx
+++ b/src/pages/Catalog2/Catalog.CollectionShimmer.tsx
@@ -37,6 +37,7 @@ export const getCollectionShimmers = (count: number) => {
   const shimmers = Array.from(Array(count).keys()).map(key => {
     return <CatalogCollectionShimmer key={`collection-shimmer-${key}`} />;
   });
+
   return (
     <Stack data-cy="collection-loading-shimmers" tokens={gap}>
       {shimmers}


### PR DESCRIPTION
Checks for existing msft:group_id and config value in frontend group settings to consolidate collections under a group page.