### PR TITLE
Provide a default API root url when none is provided

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,5 +1,7 @@
-const apiRoot = process.env.REACT_APP_API_ROOT;
-const tilerRoot = process.env.REACT_APP_TILER_ROOT || process.env.REACT_APP_API_ROOT;
+const apiRoot =
+  process.env.REACT_APP_API_ROOT ||
+  "https://planetarycomputer-staging.microsoft.com";
+const tilerRoot = process.env.REACT_APP_TILER_ROOT || apiRoot;
 
 // In some environments, there is a one-off URL for the STAC API that doesn't
 //conform to the otherwise expected path layout
@@ -16,6 +18,4 @@ export const DATA_URL = apiRoot.endsWith("stac")
   : `${tilerRoot}/api/data/v1`;
 
 export const HUB_URL = process.env.REACT_APP_HUB_URL || "";
-export const AUTH_URL =
-  process.env.REACT_APP_AUTH_URL ||
-  "https://planetarycomputer-staging.microsoft.com";
+export const AUTH_URL = process.env.REACT_APP_AUTH_URL || apiRoot;


### PR DESCRIPTION
Generally this is set in CI or on the dev machine, but for GH Actions
initiated by a non-contrib users which run the unit tests, this value
isn't injected in from the secrets. The error is about parsing a valid
URL for tests, the actual response is mocked so the default value is
not important for this purpose. However, we use staging as a sensible
default for situations when a dev environment is created without the
value set.