### PR TITLE
Fixed SAS example

### DIFF
--- a/docs/concepts/sas.md
+++ b/docs/concepts/sas.md
@@ -61,7 +61,7 @@ You can supply your subscription key in an HTTP request in two ways:
 * Supply it in an `Ocp-Apim-Subscription-Key` on request header, for example:
 
 ```bash
-curl -H "Ocp-Apim-Subscription-Key: 123456789" https://planetarycomputer.microsoft.com/api/sas/v1/token/naip?subscription-key=123456789
+curl -H "Ocp-Apim-Subscription-Key: 123456789" https://planetarycomputer.microsoft.com/api/sas/v1/token/naip
 ```
 
 * Supply it in a `subscription-key` query parameter, for example:


### PR DESCRIPTION
This example should show setting the API key through a header, not both
a header and query parameter.