### PR TITLE
Improve collection filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-datacatalog",
-  "version": "2022.2.1",
+  "version": "2022.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11611,6 +11611,11 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "minisearch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-5.0.0.tgz",
+      "integrity": "sha512-VEwBhl8aFtc2UG2XmP7a4XaZxVfNhe7GvB2W/ZRGbLL3P3LbBhkoOezBWsMqG8Mr5VonqXAMRWth79XXKja1bQ=="
     },
     "mkdirp": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "json-stringify-pretty-compact": "^4.0.0",
     "lodash-es": "^4.17.21",
     "marked": "^4.0.17",
+    "minisearch": "^5.0.0",
     "number-abbreviate": "^2.0.0",
     "process": "^0.11.10",
     "query-string": "^7.1.1",

--- a/src/pages/Catalog2/Catalog.CollectionList.tsx
+++ b/src/pages/Catalog2/Catalog.CollectionList.tsx
@@ -11,7 +11,11 @@ import { isEmpty, sortBy } from "lodash-es";
 import { CatalogCollection } from "./Catalog.Collection";
 import { getCollectionShimmers } from "./Catalog.CollectionShimmer";
 import { useCollections } from "utils/requests";
-import { GROUP_PREFIX, nonApiDatasetToPcCollection } from "./helpers";
+import {
+  GROUP_PREFIX,
+  nonApiDatasetToPcCollection,
+  groupToPcCollection,
+} from "./helpers";
 import { IPcCollection, IStacCollection } from "types/stac";
 import { useDataConfig } from "components/state/DataConfigProvider";
 
@@ -39,9 +43,9 @@ const smallThumbHeight = 112;
 export const CatalogCollectionList: React.FC<CatalogCollectionListProps> = ({
   setFilterText,
   includeStorageDatasets = true,
-  preFilterCollectionFn = () => true,
+  preFilterCollectionFn = defaultTrueFn,
   itemsAsButton = false,
-  onButtonClick = () => {},
+  onButtonClick = defaultVoidFn,
 }) => {
   const { collectionConfig, featuredIds, groupConfig, storageCollectionConfig } =
     useDataConfig();
@@ -191,18 +195,6 @@ const getCategorizedCollections = (
   return groupedCollections;
 };
 
-const groupToPcCollection = (
-  groupId: string,
-  datasetGroup: DatasetGroup
-): IPcCollection => {
-  // Construct a minimal StacCollection from the dataset details
-  const { short_description, ...group } = datasetGroup;
-  return Object.assign({}, group, {
-    "msft:short_description": datasetGroup.short_description,
-    id: GROUP_PREFIX + groupId,
-  });
-};
-
 const headerStyle: React.CSSProperties = {
   margin: 0,
 };
@@ -219,3 +211,5 @@ const separatorStyles: Partial<ISeparatorStyles> = {
     paddingTop: 0,
   },
 };
+const defaultTrueFn = () => true;
+const defaultVoidFn = () => {};

--- a/src/pages/Catalog2/Catalog.Filter.tsx
+++ b/src/pages/Catalog2/Catalog.Filter.tsx
@@ -4,6 +4,7 @@ interface CatalogFilterProps {
   filterText: string | undefined;
   onFilterChange: (_: any, newValue?: string | undefined) => void;
 }
+
 export const CatalogFilter: React.FC<CatalogFilterProps> = ({
   filterText,
   onFilterChange,

--- a/src/pages/Catalog2/Catalog.NoResults.tsx
+++ b/src/pages/Catalog2/Catalog.NoResults.tsx
@@ -6,25 +6,19 @@ const iconClass = mergeStyles({
   paddingRight: 15,
 });
 
-export const NoResults = ({ typeText = "" }) => {
+interface NoResultsProps {
+  typeText?: string;
+}
+
+export const NoResults: React.FC<NoResultsProps> = ({ typeText = "" }) => {
   return (
-    <div
-      data-cy="no-filtered-collection-results"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        border: "1px solid #ccc",
-        borderRadius: 3,
-        padding: "0 15px",
-        margin: 20,
-      }}
-    >
+    <div data-cy="no-filtered-collection-results" style={bodyStyle}>
       <FontIcon iconName="FabricFolderSearch" className={iconClass} />
       <div>
-        <h3 style={{ marginBottom: 5 }}>No Results</h3>
-        <p style={{ marginTop: 0 }}>
-          {`No ${typeText} datasets matched your filter term. `} Looking for
-          something in particular?{" "}
+        <h3 style={headerStyle}>No Results</h3>
+        <p style={contentStyle}>
+          {`No ${typeText} datasets matched your filter term. `}
+          Looking for something in particular?{" "}
           <Link href="https://github.com/microsoft/PlanetaryComputer/discussions/categories/data-request">
             Recommend a dataset
           </Link>{" "}
@@ -34,3 +28,15 @@ export const NoResults = ({ typeText = "" }) => {
     </div>
   );
 };
+
+const bodyStyle = {
+  display: "flex",
+  alignItems: "center",
+  border: "1px solid #ccc",
+  borderRadius: 3,
+  padding: "0 15px",
+  margin: 20,
+};
+
+const headerStyle = { marginBottom: 5 };
+const contentStyle = { marginTop: 0 };

--- a/src/pages/Catalog2/Catalog.Thumbnail.tsx
+++ b/src/pages/Catalog2/Catalog.Thumbnail.tsx
@@ -1,7 +1,7 @@
 import { IImageStyles, Image, ImageFit } from "@fluentui/react";
 
 interface CollectionThumbnailProps {
-  assets: Record<string, any>;
+  assets?: Record<string, any>;
 }
 
 export const CatalogCollectionThumbnail = ({ assets }: CollectionThumbnailProps) => {
@@ -15,6 +15,8 @@ export const CatalogCollectionThumbnail = ({ assets }: CollectionThumbnailProps)
       styles={imageStyles}
       imageFit={ImageFit.cover}
       data-cy="catalog-collection-thumb"
+      shouldFadeIn={false}
+      loading="lazy"
     />
   );
 };

--- a/src/pages/Catalog2/helpers.tsx
+++ b/src/pages/Catalog2/helpers.tsx
@@ -21,6 +21,18 @@ export const nonApiDatasetToPcCollection = (
   };
 };
 
+export const groupToPcCollection = (
+  groupId: string,
+  datasetGroup: DatasetGroup
+): IPcCollection => {
+  // Construct a minimal StacCollection from the dataset details
+  const { short_description, ...group } = datasetGroup;
+  return Object.assign({}, group, {
+    "msft:short_description": datasetGroup.short_description,
+    id: GROUP_PREFIX + groupId,
+  });
+};
+
 export const getCollectionDetailUrl = (id: string) => {
   if (id.startsWith(GROUP_PREFIX)) {
     return `/dataset/group/${id.substring(GROUP_PREFIX.length)}`;

--- a/src/pages/Explore/components/Sidebar/selectors/CatalogSelector/CatalogSelector.index.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/CatalogSelector/CatalogSelector.index.tsx
@@ -103,7 +103,7 @@ export const CatalogSelector = () => {
               itemsAsButton
               includeStorageDatasets={false}
               preFilterCollectionFn={isValidExplorer}
-              setFilterText={handleFilterChange}
+              setFilterText={setFilterText}
               onButtonClick={handleSelection}
             />
           </div>
@@ -113,7 +113,7 @@ export const CatalogSelector = () => {
             itemsAsButton
             includeStorageDatasets={false}
             preFilterCollectionFn={isValidExplorer}
-            setFilterText={handleFilterChange}
+            setFilterText={setFilterText}
             onButtonClick={handleSelection}
             filterText={filterText}
           />

--- a/src/pages/Explore/explorer.css
+++ b/src/pages/Explore/explorer.css
@@ -25,7 +25,7 @@
   display: none;
 }
 
-.ms-Modal h2 {
+.ms-Modal .catalog-filter-results-header {
   padding-left: 8px;
 }
 

--- a/src/types/stac.d.ts
+++ b/src/types/stac.d.ts
@@ -6,18 +6,17 @@ export interface IPcCollection {
   title: string;
   description: string;
   summaries?: Record<string, Optional<[]>>;
-  assets: Record<string, IStacAsset>;
+  assets?: Record<string, IStacAsset>;
   item_assets?: Record<string, IStacAsset>;
   keywords: string[];
+  providers?: IStacProvider[];
   "msft:short_description": string;
   "msft:group_id"?: string;
   "cube:variables"?: Record<string, Record<string, any>>;
 }
 
 export interface IStacCollection extends IPcCollection {
-  summaries?: Record<string, []>;
   license: string;
-  item_assets: Record<string, IStacAsset>;
   extent: {
     spatial: {
       bbox: Array<Array<number>>;
@@ -26,12 +25,17 @@ export interface IStacCollection extends IPcCollection {
       interval: Array<Array<string | null>>;
     };
   };
+  item_assets: Record<string, IStacAsset>;
+  assets: Record<string, IStacAsset>;
   links: IStacLink[];
-  summaries?: Record<string, []>;
   "msft:requires_account"?: boolean;
-  "cube:variables"?: Record<string, Record<string, any>>;
 }
 
+export interface IStacProvider {
+  name: string;
+  url: string;
+  roles: string[];
+}
 export interface IStacLink {
   href: string;
   rel: string;

--- a/src/types/stac.d.ts
+++ b/src/types/stac.d.ts
@@ -5,11 +5,15 @@ export interface IPcCollection {
   id: string;
   title: string;
   description: string;
+  summaries?: Record<string, Optional<[]>>;
   assets: Record<string, IStacAsset>;
+  item_assets?: Record<string, IStacAsset>;
   keywords: string[];
   "msft:short_description": string;
   "msft:group_id"?: string;
+  "cube:variables"?: Record<string, Record<string, any>>;
 }
+
 export interface IStacCollection extends IPcCollection {
   summaries?: Record<string, []>;
   license: string;
@@ -23,8 +27,9 @@ export interface IStacCollection extends IPcCollection {
     };
   };
   links: IStacLink[];
-  summaries?: Record<string, string>;
+  summaries?: Record<string, []>;
   "msft:requires_account"?: boolean;
+  "cube:variables"?: Record<string, Record<string, any>>;
 }
 
 export interface IStacLink {

--- a/src/utils/stac.js
+++ b/src/utils/stac.js
@@ -530,6 +530,12 @@ export const mediaTypeOverride = value => {
       return "GeoTIFF (COG)";
     case "application/x-parquet":
       return "Parquet";
+    case "application/x-hdf":
+      return "HDF";
+    case "application/vnd.laszip+copc":
+      return "COPC";
+    case "application/vnd+zarr":
+      return "Zarr";
     default:
       return StacFields.Formatters.formatMediaType(value);
   }


### PR DESCRIPTION
Adds a client side search index and index the following fields:
- id
- title
- msft:short_description
- cube:variables[standard_name]
- summaries[eo:bands][common_name]
- assets|item_assets[type] (formatted)
- providers

Also optimizes the index build and collection pre-filtering by correctly
memoizing based on default function prop values.

Results are now returned in score order, not alphabetically. Based on
the current 80+ collections, searches perform typically in under 1ms.