### PR TITLE
Fix IO LULC map link on apps page

### DIFF
--- a/src/config/apps.yml
+++ b/src/config/apps.yml
@@ -7,7 +7,7 @@
   thumbnailUrl: ./images/apps/io-lulc-wide-fs8.jpg
   links:
     - title: Explore land classification
-      url: https://www.impactobservatory.com/lulc_map
+      url: https://www.impactobservatory.com/global_maps
     - title: Learn about Impact Observatory
       url: https://www.impactobservatory.com/
 


### PR DESCRIPTION
Previous IO link is no longer valid.