### PR TITLE
Added data API quickstart

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ quickstarts/reading-zarr-data
 quickstarts/stac-geoparquet
 quickstarts/reading-tabular-data
 quickstarts/scale-with-dask
+quickstarts/using-the-data-api
 quickstarts/using-radiant-mlhub-api
 quickstarts/storage
 ```

--- a/etl/config/codefiles_urls.txt
+++ b/etl/config/codefiles_urls.txt
@@ -10,6 +10,7 @@ https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datas
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/quickstarts/reading-stac-r.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/quickstarts/stac-geoparquet.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/quickstarts/using-radiant-mlhub-api.ipynb
+https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/quickstarts/using-the-data-api.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/quickstarts/reading-zarr-data.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/goes/goes-cmi-example.ipynb
 https://raw.githubusercontent.com/microsoft/PlanetaryComputerExamples/main/datasets/hgb/hgb-example.ipynb

--- a/etl/config/external_docs_config.yml
+++ b/etl/config/external_docs_config.yml
@@ -24,6 +24,7 @@
 - file_url: quickstarts/reading-stac-r.ipynb
 - file_url: quickstarts/stac-geoparquet.ipynb
 - file_url: quickstarts/using-radiant-mlhub-api.ipynb
+- file_url: quickstarts/using-the-data-api.ipynb
 - file_url: quickstarts/reading-tabular-data.ipynb
 - file_url: quickstarts/reading-zarr-data.ipynb
 - file_url: quickstarts/storage.ipynb

--- a/etl/scripts/build_codefiles
+++ b/etl/scripts/build_codefiles
@@ -6,6 +6,8 @@ rm _codefile_output/*.md || true
 # Download all the notebooks and markdown files specified
 wget -nv -i config/codefiles_urls.txt -P ./_codefile_output
 
+jupyter trust ./_codefile_output/*.ipynb
+
 # Convert the notebooks to a basic html output, without body or style tags
 jupyter nbconvert --to html --template basic ./_codefile_output/*.ipynb
 

--- a/etl/scripts/build_codefiles
+++ b/etl/scripts/build_codefiles
@@ -6,8 +6,6 @@ rm _codefile_output/*.md || true
 # Download all the notebooks and markdown files specified
 wget -nv -i config/codefiles_urls.txt -P ./_codefile_output
 
-jupyter trust ./_codefile_output/*.ipynb
-
 # Convert the notebooks to a basic html output, without body or style tags
 jupyter nbconvert --to html --template basic ./_codefile_output/*.ipynb
 

--- a/src/pages/Docs/components/DocsHtmlContent.tsx
+++ b/src/pages/Docs/components/DocsHtmlContent.tsx
@@ -116,7 +116,8 @@ const DocsHtmlContent: React.FC<DocsHtmlContentProps> = ({
         ref={contentRef}
         onClick={handleClick}
         dangerouslySetInnerHTML={{
-          __html: DOMPurify.sanitize(bodyWithRoutedLinks),
+          // __html: DOMPurify.sanitize(bodyWithRoutedLinks),
+          __html: bodyWithRoutedLinks
         }}
       />
     </div>

--- a/src/pages/Docs/components/DocsHtmlContent.tsx
+++ b/src/pages/Docs/components/DocsHtmlContent.tsx
@@ -109,6 +109,10 @@ const DocsHtmlContent: React.FC<DocsHtmlContentProps> = ({
     }
   });
 
+  const html = allowList.includes(current_page_name)
+    ? bodyWithRoutedLinks
+    : DOMPurify.sanitize(bodyWithRoutedLinks);
+
   const content = processedMarkup ? (
     <div className={className}>
       {children}
@@ -116,8 +120,7 @@ const DocsHtmlContent: React.FC<DocsHtmlContentProps> = ({
         ref={contentRef}
         onClick={handleClick}
         dangerouslySetInnerHTML={{
-          // __html: DOMPurify.sanitize(bodyWithRoutedLinks),
-          __html: bodyWithRoutedLinks,
+          __html: html,
         }}
       />
     </div>
@@ -127,3 +130,6 @@ const DocsHtmlContent: React.FC<DocsHtmlContentProps> = ({
 };
 
 export default DocsHtmlContent;
+
+// Skip dom sanitizations for pages that embed scripts
+const allowList = ["quickstarts/using-the-data-api"];

--- a/src/pages/Docs/components/DocsHtmlContent.tsx
+++ b/src/pages/Docs/components/DocsHtmlContent.tsx
@@ -117,7 +117,7 @@ const DocsHtmlContent: React.FC<DocsHtmlContentProps> = ({
         onClick={handleClick}
         dangerouslySetInnerHTML={{
           // __html: DOMPurify.sanitize(bodyWithRoutedLinks),
-          __html: bodyWithRoutedLinks
+          __html: bodyWithRoutedLinks,
         }}
       />
     </div>


### PR DESCRIPTION
https://github.com/microsoft/PlanetaryComputerExamples/pull/207 switched that notebook to using folium, which renders widgets inside of an iframe, which (should) make its way through the doc build intact.