### PR TITLE
Catalog/explorer rendering

### DIFF
--- a/src/components/controls/NamedEntry.tsx
+++ b/src/components/controls/NamedEntry.tsx
@@ -1,0 +1,53 @@
+import { Separator, Text } from "@fluentui/react";
+import { CSSProperties } from "react";
+
+type INamedEntry = {
+  name: string;
+  description?: string;
+  [key: string]: any;
+};
+
+interface NamedEntryProps {
+  entry: INamedEntry;
+}
+
+const NamedEntry: React.FC<NamedEntryProps> = ({ entry }) => {
+  const extraKeys = Object.keys(entry).filter(
+    key => !["name", "description"].includes(key)
+  );
+
+  return (
+    <div className="named-entry">
+      <Separator />
+      <h4 style={headerStyle}>{entry.name}</h4>
+      <Text block styles={descStyles}>
+        {entry.description}
+      </Text>
+      <ul style={listStyles}>
+        {extraKeys.map(key => (
+          <li key={key}>
+            {key}: {entry[key]}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default NamedEntry;
+
+const headerStyle: CSSProperties = {
+  marginBottom: 4,
+};
+
+const descStyles = {
+  root: {
+    "&:first-letter": {
+      textTransform: "capitalize",
+    },
+  },
+};
+
+const listStyles: CSSProperties = {
+  margin: "7px 0",
+};

--- a/src/components/stac/ItemAssets.tsx
+++ b/src/components/stac/ItemAssets.tsx
@@ -29,6 +29,7 @@ export const ASSET_DETAIL_KEYS = [
   "raster:bands",
   "classification:classes",
   "classification:bitfields",
+  "table:columns",
 ];
 
 const ItemAssets = () => {

--- a/src/components/stac/ItemAssets.tsx
+++ b/src/components/stac/ItemAssets.tsx
@@ -32,6 +32,8 @@ export const ASSET_DETAIL_KEYS = [
   "table:columns",
 ];
 
+export const SUPRESSED_KEYS = ["xarray:open_kwargs"];
+
 const ItemAssets = () => {
   const collection = useStac();
   if (!collection) return null;
@@ -51,7 +53,9 @@ const ItemAssets = () => {
         })
         .flat()
     )
-  ).concat(["stac_key"]);
+  )
+    .filter(key => !SUPRESSED_KEYS.includes(key))
+    .concat(["stac_key"]);
 
   // Special keys which can be long or many-to-one with an asset get plucked out
   // and ultimately rendered in a detail pane. Remove these keys, and if they existed

--- a/src/pages/Explore/components/ItemResult.tsx
+++ b/src/pages/Explore/components/ItemResult.tsx
@@ -1,5 +1,14 @@
-import { IStyle, Link, Stack, Text, useTheme } from "@fluentui/react";
-import { useCallback } from "react";
+import {
+  getTheme,
+  ILinkStyleProps,
+  ILinkStyles,
+  IStyle,
+  IStyleFunctionOrObject,
+  Link,
+  Stack,
+  Text,
+} from "@fluentui/react";
+import { CSSProperties, useCallback } from "react";
 import { IStacItem } from "types/stac";
 import ItemPreview from "./ItemPreview";
 import { setSelectedItem } from "../state/detailSlice";
@@ -12,23 +21,60 @@ type ItemResultProps = {
 };
 
 const ItemResult = ({ item }: ItemResultProps) => {
-  const theme = useTheme();
   const dispatch = useExploreDispatch();
 
-  const hoverStyle: IStyle = {
-    background: theme.palette.themeLighterAlt,
-    boxShadow: theme.effects.elevation8,
-    color: theme.palette.black,
-    cursor: "pointer",
-    textDecoration: "none",
-  };
+  const showBounds = useCallback(() => {
+    dispatch(setBoundaryShape(item.geometry));
+  }, [dispatch, item.geometry]);
 
-  const activeStyle: IStyle = {
-    textDecoration: "none",
-    color: theme.palette.black,
-  };
+  const removeBounds = useCallback(() => {
+    dispatch(clearBoundaryShape());
+  }, [dispatch]);
 
-  const rootStyle: IStyle = {
+  return (
+    <Link
+      onClick={() => dispatch(setSelectedItem(item))}
+      styles={linkStyle}
+      onMouseEnter={showBounds}
+      onMouseLeave={removeBounds}
+      data-cy="item-result"
+    >
+      <Stack
+        horizontal
+        tokens={{ childrenGap: 10 }}
+        styles={{ root: { padding: 0 } }}
+      >
+        <div style={wrapperStyle}>
+          <ItemPreview item={item} key={item.id} />
+        </div>
+        <Stack verticalAlign={"space-evenly"} style={{ paddingRight: "10px" }}>
+          <Text styles={idStyles}>{item.id}</Text>
+          <PriorityAttributes item={item} />
+        </Stack>
+      </Stack>
+    </Link>
+  );
+};
+
+export default ItemResult;
+
+const theme = getTheme();
+
+const hoverStyle: IStyle = {
+  background: theme.palette.themeLighterAlt,
+  boxShadow: theme.effects.elevation8,
+  color: theme.palette.black,
+  cursor: "pointer",
+  textDecoration: "none",
+};
+
+const activeStyle: IStyle = {
+  textDecoration: "none",
+  color: theme.palette.black,
+};
+
+const linkStyle: IStyleFunctionOrObject<ILinkStyleProps, ILinkStyles> = {
+  root: {
     borderWidth: 1,
     borderColor: theme.palette.neutralQuaternary,
     borderStyle: "solid",
@@ -43,51 +89,22 @@ const ItemResult = ({ item }: ItemResultProps) => {
     ":focus": activeStyle,
     ":active": activeStyle,
     ":active:hover": activeStyle,
-  };
-
-  const showBounds = useCallback(() => {
-    dispatch(setBoundaryShape(item.geometry));
-  }, [dispatch, item.geometry]);
-
-  const removeBounds = useCallback(() => {
-    dispatch(clearBoundaryShape());
-  }, [dispatch]);
-
-  return (
-    <Link
-      onClick={() => dispatch(setSelectedItem(item))}
-      styles={{ root: rootStyle }}
-      onMouseEnter={showBounds}
-      onMouseLeave={removeBounds}
-      data-cy="item-result"
-    >
-      <Stack
-        horizontal
-        tokens={{ childrenGap: 10 }}
-        styles={{ root: { padding: 0 } }}
-      >
-        <div
-          style={{
-            minWidth: 100,
-            minHeight: 100,
-            borderRight: theme.palette.neutralLighter,
-            borderRightWidth: 1,
-            borderRightStyle: "solid",
-            backgroundColor: theme.palette.black,
-            borderRadius: "0",
-          }}
-        >
-          <ItemPreview item={item} key={item.id} />
-        </div>
-        <Stack verticalAlign={"space-evenly"} style={{ paddingRight: "10px" }}>
-          <Text styles={{ root: { fontWeight: "600", overflowWrap: "anywhere" } }}>
-            {item.id}
-          </Text>
-          <PriorityAttributes item={item} />
-        </Stack>
-      </Stack>
-    </Link>
-  );
+  },
 };
 
-export default ItemResult;
+const wrapperStyle: CSSProperties = {
+  minWidth: 100,
+  minHeight: 100,
+  borderRight: theme.palette.neutralLighter,
+  borderRightWidth: 1,
+  borderRightStyle: "solid",
+  backgroundColor: theme.palette.black,
+  borderRadius: "0",
+};
+
+const idStyles = {
+  root: {
+    fontWeight: "600",
+    overflowWrap: "anywhere",
+  },
+};

--- a/src/pages/Explore/components/Map/components/LegendControl/LayerOverflowOptions.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/LayerOverflowOptions.tsx
@@ -1,4 +1,8 @@
-import { IconButton, IContextualMenuProps } from "@fluentui/react";
+import {
+  IconButton,
+  IContextualMenuItem,
+  IContextualMenuProps,
+} from "@fluentui/react";
 import { useExploreDispatch, useExploreSelector } from "pages/Explore/state/hooks";
 import {
   moveLayerDown,
@@ -21,12 +25,16 @@ const LayerOverflowOptions: React.FC<LayerOverflowOptionsProps> = ({
   const { currentEditingLayerId, layerOrder } = useExploreSelector(s => s.mosaic);
   const isEditing = layerId === currentEditingLayerId;
 
+  const handlePin = useCallback(() => {
+    currentEditingLayerId && dispatch(pinCurrentMosaic());
+  }, [currentEditingLayerId, dispatch]);
+
   const handleEdit = useCallback(() => {
     // If there is a layer being edited, pin it so the current map isn't disrupted
     // when reloading this layer to the sidebar.
-    currentEditingLayerId && dispatch(pinCurrentMosaic());
+    handlePin();
     dispatch(setCurrentEditingLayerId(layerId));
-  }, [dispatch, currentEditingLayerId, layerId]);
+  }, [dispatch, handlePin, layerId]);
 
   const handleMoveUp = useCallback(() => {
     dispatch(moveLayerUp(layerId));
@@ -39,16 +47,28 @@ const LayerOverflowOptions: React.FC<LayerOverflowOptionsProps> = ({
   const canMoveUp = layerOrder[0] !== layerId;
   const canMoveDown = layerOrder[layerOrder.length - 1] !== layerId;
 
+  const pinOrEditItem: IContextualMenuItem = useMemo(() => {
+    if (isPinned && !isEditing) {
+      return {
+        key: "re-edit",
+        text: "Edit layer and filter options",
+        iconProps: { iconName: "Edit" },
+        onClick: handleEdit,
+      };
+    }
+
+    return {
+      key: "re-pin",
+      text: "Stop editing",
+      iconProps: { iconName: "PencilReply" },
+      onClick: handlePin,
+    };
+  }, [handleEdit, handlePin, isEditing, isPinned]);
+
   const menuProps: IContextualMenuProps = useMemo(() => {
     return {
       items: [
-        {
-          key: "re-edit",
-          text: "Edit layer/filter options",
-          iconProps: { iconName: "Edit" },
-          disabled: !isPinned || isEditing,
-          onClick: handleEdit,
-        },
+        pinOrEditItem,
         {
           key: "moveup",
           text: "Move layer up",
@@ -73,15 +93,7 @@ const LayerOverflowOptions: React.FC<LayerOverflowOptionsProps> = ({
         },
       },
     };
-  }, [
-    isPinned,
-    isEditing,
-    handleEdit,
-    canMoveUp,
-    handleMoveUp,
-    canMoveDown,
-    handleMoveDown,
-  ]);
+  }, [pinOrEditItem, canMoveUp, handleMoveUp, canMoveDown, handleMoveDown]);
 
   return (
     <IconButton

--- a/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
+++ b/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { ILegendConfig } from "pages/Explore/types";
 import { QueryFunctionContext, useQuery } from "react-query";
 import { QsParamType } from "types";

--- a/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
+++ b/src/pages/Explore/components/Map/components/LegendControl/helpers.ts
@@ -9,6 +9,7 @@ import {
   IStacCollection,
 } from "types/stac";
 import { DATA_URL } from "utils/constants";
+import { pcApiClient } from "utils/requests";
 
 export const rootColormapUrl = `${DATA_URL}/legend/colormap`;
 export const rootClassmapUrl = `${DATA_URL}/legend/classmap`;
@@ -88,6 +89,6 @@ const getLegendMappingByName = async (
   const rootUrl = legendType === "classmap" ? rootClassmapUrl : rootIntervalUrl;
 
   return await (
-    await axios.get(`${rootUrl}/${classmapName}${qsConfig}`)
+    await pcApiClient.get(`${rootUrl}/${classmapName}${qsConfig}`)
   ).data;
 };

--- a/src/pages/Explore/components/Map/helpers.ts
+++ b/src/pages/Explore/components/Map/helpers.ts
@@ -1,0 +1,28 @@
+import atlas, { ResourceType } from "azure-maps-control";
+import { DATA_URL, REQUEST_ENTITY, X_REQUEST_ENTITY } from "utils/constants";
+
+// Add request entity header to all tiler requests
+export const addEntityHeader = (
+  url: string,
+  resourceType: ResourceType
+): atlas.RequestParameters => {
+  if (resourceType === "Tile" && url?.startsWith(DATA_URL)) {
+    return {
+      headers: {
+        [X_REQUEST_ENTITY]: REQUEST_ENTITY,
+      },
+    };
+  }
+  return {};
+};
+
+// const addAuthHeaders = (
+//   url: string,
+//   resourceType: atlas.ResourceType
+// ): atlas.RequestParameters => {
+//   resourceType === "Tile" && console.log(url, resourceType, DATA_URL);
+//   if (resourceType === "Tile" && url?.startsWith(DATA_URL)) {
+//     return { headers: { Authorization: `Bearer ${sessionStatus.token}` } };
+//   }
+//   return {};
+// };

--- a/src/pages/Explore/components/Map/index.tsx
+++ b/src/pages/Explore/components/Map/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import * as atlas from "azure-maps-control";
 import "azure-maps-control/dist/atlas.min.css";
 
@@ -27,9 +27,8 @@ import {
 import MapSettingsControl from "./components/MapSettingsControl";
 import { DEFAULT_MAP_STYLE } from "pages/Explore/utils/constants";
 import LegendControl from "./components/LegendControl";
-import { useSession } from "components/auth/hooks/SessionContext";
-import { DATA_URL } from "utils/constants";
 import { MobileViewSidebarButton } from "../MobileViewInMap/ViewInMap.index";
+import { addEntityHeader } from "./helpers";
 
 const mapContainerId: string = "viewer-map";
 
@@ -38,18 +37,7 @@ const ExploreMap = () => {
   const { center, zoom, showSidebar } = useExploreSelector(s => s.map);
   const [mapReady, setMapReady] = useState<boolean>(false);
   const mapHandlers = useMapEvents(mapRef);
-  const { status: sessionStatus } = useSession();
-
-  const addAuthHeaders = useCallback(
-    (url: string, resourceType: atlas.ResourceType): atlas.RequestParameters => {
-      resourceType === "Tile" && console.log(url, resourceType, DATA_URL);
-      if (resourceType === "Tile" && url?.startsWith(DATA_URL)) {
-        return { headers: { Authorization: `Bearer ${sessionStatus.token}` } };
-      }
-      return {};
-    },
-    [sessionStatus]
-  );
+  // const { status: sessionStatus } = useSession();
 
   // Initialize the map
   useEffect(() => {
@@ -69,6 +57,7 @@ const ExploreMap = () => {
           authType: atlas.AuthenticationType.subscriptionKey,
           subscriptionKey: process.env.REACT_APP_AZMAPS_KEY,
         },
+        transformRequest: addEntityHeader,
       });
 
       map.events.add("ready", onReady);
@@ -99,18 +88,18 @@ const ExploreMap = () => {
   }, [mapReady]);
 
   // When logged in, transform requests to include auth header
-  useEffect(() => {
-    if (sessionStatus.isLoggedIn) {
-      console.log("Activating auth headers for tile requests");
-      mapRef.current?.setServiceOptions({ transformRequest: addAuthHeaders });
-    } else {
-      mapRef.current?.setServiceOptions({
-        transformRequest: () => {
-          return {};
-        },
-      });
-    }
-  }, [addAuthHeaders, sessionStatus]);
+  // useEffect(() => {
+  //   if (sessionStatus.isLoggedIn) {
+  //     console.log("Activating auth headers for tile requests");
+  //     mapRef.current?.setServiceOptions({ transformRequest: addAuthHeaders });
+  //   } else {
+  //     mapRef.current?.setServiceOptions({
+  //       transformRequest: () => {
+  //         return {};
+  //       },
+  //     });
+  //   }
+  // }, [addAuthHeaders, sessionStatus]);
 
   useItemBoundsLayer(mapRef, mapReady);
   useCollectionBoundsLayer(mapRef, mapReady);

--- a/src/pages/Explore/components/controls/PriorityAttributes.tsx
+++ b/src/pages/Explore/components/controls/PriorityAttributes.tsx
@@ -1,7 +1,7 @@
 import { Stack, StackItem, useTheme } from "@fluentui/react";
 import { isNumber } from "lodash-es";
 
-import { toUtcDateString } from "utils";
+import { toDateWithTime24, toUtcDateString } from "utils";
 import { IStacItem } from "types/stac";
 import IconValue from "./IconValue";
 
@@ -15,7 +15,7 @@ const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
   const cloud = item.properties?.["eo:cloud_cover"];
 
   // Items typically have a datetime, if not, they'll have start_/end_datetime
-  const date = item.properties?.datetime;
+  const date = item.properties?.datetime as string;
   const dateRange = [
     item.properties?.start_datetime,
     item.properties?.end_datetime,
@@ -29,7 +29,7 @@ const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
   );
 
   const dtTitle = !hasRange && date && (
-    <span title="Acquisition date">{toUtcDateString(date)}</span>
+    <span title="Acquisition date (UTC)">{toDateWithTime24(date)}</span>
   );
 
   return (

--- a/src/pages/Explore/utils/hooks/useCollectionMosaicInfo.ts
+++ b/src/pages/Explore/utils/hooks/useCollectionMosaicInfo.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { IMosaicInfo } from "pages/Explore/types";
 import { QueryFunctionContext, useQuery } from "react-query";
 import { IStacCollection } from "types/stac";

--- a/src/pages/Explore/utils/hooks/useCollectionMosaicInfo.ts
+++ b/src/pages/Explore/utils/hooks/useCollectionMosaicInfo.ts
@@ -3,6 +3,7 @@ import { IMosaicInfo } from "pages/Explore/types";
 import { QueryFunctionContext, useQuery } from "react-query";
 import { IStacCollection } from "types/stac";
 import { DATA_URL, STAC_URL } from "utils/constants";
+import { pcApiClient } from "utils/requests";
 
 export const useCollectionMosaicInfo = (collectionId: string | undefined) => {
   return useQuery(["mosaicinfo", collectionId], getCollectionMosaicParams, {
@@ -23,7 +24,7 @@ export const fetchCollectionMosaicInfo = async (
   collectionId: string | undefined
 ): Promise<IMosaicInfo> => {
   return await (
-    await axios.get(`${DATA_URL}/mosaic/info?collection=${collectionId}`)
+    await pcApiClient.get(`${DATA_URL}/mosaic/info?collection=${collectionId}`)
   ).data;
 };
 
@@ -31,6 +32,6 @@ export const fetchCollection = async (
   collectionId: string
 ): Promise<IStacCollection> => {
   return await (
-    await axios.get(`${STAC_URL}/collections/${collectionId}`)
+    await pcApiClient.get(`${STAC_URL}/collections/${collectionId}`)
   ).data;
 };

--- a/src/pages/Explore/utils/hooks/useSearchIdMetadata.ts
+++ b/src/pages/Explore/utils/hooks/useSearchIdMetadata.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { ISearchIdMetadata } from "pages/Explore/types";
 import { QueryFunctionContext, useQuery } from "react-query";
 import { DATA_URL } from "utils/constants";
+import { pcApiClient } from "utils/requests";
 
 export const useSearchIdMetadata = (searchId: string | null) => {
   return useQuery(["searchId", searchId], getSearchIdMetadata, {
@@ -22,6 +23,6 @@ export const fetchSearchIdMetadata = async (
   searchId: string | null
 ): Promise<ISearchIdMetadata> => {
   return await (
-    await axios.get(`${DATA_URL}/mosaic/${searchId}/info`)
+    await pcApiClient.get(`${DATA_URL}/mosaic/${searchId}/info`)
   ).data;
 };

--- a/src/pages/Explore/utils/hooks/useSearchIdMetadata.ts
+++ b/src/pages/Explore/utils/hooks/useSearchIdMetadata.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { ISearchIdMetadata } from "pages/Explore/types";
 import { QueryFunctionContext, useQuery } from "react-query";
 import { DATA_URL } from "utils/constants";

--- a/src/pages/Explore/utils/hooks/useStacSearch.ts
+++ b/src/pages/Explore/utils/hooks/useStacSearch.ts
@@ -1,8 +1,8 @@
-import axios from "axios";
 // import { useSession } from "components/auth/hooks/SessionContext";
 import { QueryFunctionContext, useQuery, UseQueryResult } from "react-query";
 import { IStacFilter, IStacSearchResult } from "types/stac";
 import { STAC_URL } from "utils/constants";
+import { pcApiClient } from "utils/requests";
 
 const getStacItems = async (
   queryParam: QueryFunctionContext<[string, IStacFilter | undefined]>
@@ -13,7 +13,7 @@ const getStacItems = async (
     return Promise.reject();
   }
 
-  const resp = await axios.post(`${STAC_URL}/search`, search);
+  const resp = await pcApiClient.post(`${STAC_URL}/search`, search);
 
   return resp.data;
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -20,3 +20,7 @@ export const DATA_URL = apiRoot.endsWith("stac")
 export const IMAGE_URL = process.env.REACT_APP_IMAGE_API_ROOT || "";
 export const HUB_URL = process.env.REACT_APP_HUB_URL || "";
 export const AUTH_URL = process.env.REACT_APP_AUTH_URL || apiRoot;
+
+export const X_REQUEST_ENTITY = "X-PC-Request-Entity";
+export const QS_REQUEST_ENTITY = "request_entity";
+export const REQUEST_ENTITY = "explorer";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,6 +33,9 @@ export const toUtcDateString = (dt: string | Date | Dayjs) => {
 export const toUtcDateWithTime = (dt: string) =>
   dayjs.utc(dt).format("MM/DD/YYYY, h:mm:ss A UTC");
 
+export const toDateWithTime24 = (dt: string) =>
+  dayjs.utc(dt).format("MM/DD/YYYY, HH:mm:ss");
+
 export const toIsoDateString = (
   dt: string | Date | Dayjs,
   includeTime: boolean = true

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,7 @@ import dayjs, { Dayjs } from "dayjs";
 import utc from "dayjs/plugin/utc";
 
 import { IStacCollection, IStacItem } from "types/stac";
-import { DATA_URL, HUB_URL } from "./constants";
+import { DATA_URL, HUB_URL, QS_REQUEST_ENTITY, REQUEST_ENTITY } from "./constants";
 import * as qs from "query-string";
 import { IMosaic, IMosaicRenderOption } from "pages/Explore/types";
 import { DEFAULT_MIN_ZOOM } from "pages/Explore/utils/constants";
@@ -242,12 +242,11 @@ export const useItemPreviewUrl = (
   renderOption: IMosaicRenderOption | null,
   size?: number
 ) => {
-  // TODO: add auth to request: const { status } = useSession();
   const maxSize = size ? `&max_size=${size}` : "";
   const url = encodeURI(`${DATA_URL}/item/preview.png`);
   const renderParams = encodeRenderOpts(removeMercatorAssets(renderOption?.options));
 
-  const params = `?collection=${item.collection}&item=${item.id}&${renderParams}${maxSize}`;
+  const params = `?collection=${item.collection}&item=${item.id}&${renderParams}${maxSize}&${QS_REQUEST_ENTITY}=${REQUEST_ENTITY}`;
 
   return url + params;
 };

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -7,12 +7,22 @@ import { makeFilterBody } from "pages/Explore/utils/hooks/useStacFilter";
 import { collectionFilter } from "pages/Explore/utils/stac";
 import { IStacCollection, IStacItem } from "types/stac";
 import { makeTileJsonUrl } from "utils";
-import { DATA_URL, IMAGE_URL, STAC_URL } from "./constants";
+import {
+  DATA_URL,
+  IMAGE_URL,
+  REQUEST_ENTITY,
+  STAC_URL,
+  X_REQUEST_ENTITY,
+} from "./constants";
 import datasetConfig from "config/datasets.yml";
 import { AnimationConfig } from "pages/Explore/components/Sidebar/AnimationExporter/types";
 import { AnimationResponse } from "pages/Explore/components/Sidebar/AnimationExporter/AnimationResult";
 
-// import { useSession } from "components/auth/hooks/SessionContext";
+export const pcApiClient = axios.create({
+  headers: {
+    [X_REQUEST_ENTITY]: REQUEST_ENTITY,
+  },
+});
 
 // Query content can be prefetched if it's likely to be used
 export const usePrefetchContent = () => {
@@ -68,7 +78,7 @@ const getAnimationExport = async (
   queryParam: QueryFunctionContext<[string, AnimationConfig | undefined]>
 ): Promise<AnimationResponse> => {
   const config = queryParam.queryKey[1];
-  const resp = await axios.post(`${IMAGE_URL}/animation`, config);
+  const resp = await pcApiClient.post(`${IMAGE_URL}/animation`, config);
 
   // For local development, swapt out azurite host with localhost
   const { url } = resp.data;
@@ -95,7 +105,7 @@ export const fetchTileJson = async (
 ) => {
   const tileJsonUrl = makeTileJsonUrl(query, renderOption, collection, item);
 
-  const resp = await axios.get(tileJsonUrl);
+  const resp = await pcApiClient.get(tileJsonUrl);
   return resp.data;
 };
 
@@ -116,14 +126,14 @@ export const registerStacFilter = async (
   // Make a new request
   const dataUrl = DATA_URL;
   const body = makeFilterBody([collectionFilter(collectionId)], queryInfo, cql);
-  const r = await axios.post(`${dataUrl}/mosaic/register`, body, {
+  const r = await pcApiClient.post(`${dataUrl}/mosaic/register`, body, {
     cancelToken: new axios.CancelToken(c => (registerCancelToken = c)),
   });
   return r.data.searchid;
 };
 
 const getCollections = async (): Promise<{ collections: IStacCollection[] }> => {
-  const resp = await axios.get(`${STAC_URL}/collections`);
+  const resp = await pcApiClient.get(`${STAC_URL}/collections`);
 
   // Collections in the API can be configured to be hidden in all frontend contexts.
   const hiddenCollections = Object.entries(datasetConfig || {})

--- a/src/utils/stac.js
+++ b/src/utils/stac.js
@@ -16,6 +16,7 @@ import NewTabLink from "../components/controls/NewTabLink";
 import SimpleKeyValueList from "../components/controls/SimpleKeyValueList";
 import Revealer from "../components/Revealer";
 import AssetDetails from "components/stac/AssetDetails";
+import NamedEntry from "components/controls/NamedEntry";
 
 const stringList = value => {
   return Array.isArray(value) ? value.map(capitalize).join(", ") : capitalize(value);
@@ -476,6 +477,17 @@ StacFields.Registry.addMetadataField("view:sun_elevation", {
   formatter: fixedDeg,
 });
 
+StacFields.Registry.addMetadataField("table:columns", {
+  formatter: value => {
+    return (
+      <Stack>
+        {value.map(column => (
+          <NamedEntry entry={column} />
+        ))}
+      </Stack>
+    );
+  },
+});
 StacFields.Registry.addMetadataField("table:storage_options", {
   formatter: value => <SimpleKeyValueList object={value} />,
 });

--- a/src/utils/stac.js
+++ b/src/utils/stac.js
@@ -70,6 +70,10 @@ StacFields.Registry.addMetadataField("attrs", {
   formatter: value => value,
 });
 
+StacFields.Registry.addMetadataField("xarray:open_kwargs", {
+  formatter: () => null,
+});
+
 StacFields.Registry.addMetadataField("raster:bands", {
   label: "Raster Info",
   formatter: value => {


### PR DESCRIPTION
- Supports `table:columns` extension in catalog when used within `item_assets`.
- Prevent rendering of `open_kwargs` field
- Add stop editing button to "re-pin" layer
- Add timestamp to search result cards when using dateime only
- Add header for requests made by site for better origin logging