### PR TITLE
Make Explorer time-aware

### DIFF
--- a/src/components/stac/TemporalExtent.tsx
+++ b/src/components/stac/TemporalExtent.tsx
@@ -1,6 +1,6 @@
 import { Text } from "@fluentui/react";
+import { formatDateShort } from "pages/Explore/utils/time";
 import { IStacCollection } from "types/stac";
-import { toUtcDateString } from "utils";
 import LabeledValue from "../controls/LabeledValue";
 
 interface TemporalExtentProps {
@@ -15,8 +15,8 @@ const TemporalExtent: React.FC<TemporalExtentProps> = ({
   const formatted = extent.interval.map((period, idx) => {
     const [start, end] = period;
 
-    const startFormat = toUtcDateString(start as string);
-    const endFormat = end ? toUtcDateString(end) : "Present";
+    const startFormat = formatDateShort(start as string);
+    const endFormat = end ? formatDateShort(end) : "Present";
     return (
       <Text block key={`temporal-${idx}`}>{`${startFormat} – ${endFormat}`}</Text>
     );

--- a/src/pages/Catalog2/Catalog.FilteredCollectionList.tsx
+++ b/src/pages/Catalog2/Catalog.FilteredCollectionList.tsx
@@ -89,7 +89,6 @@ export const CatalogFilteredCollectionList: React.FC<
   }, [data, includeStorageDatasets, preFilterCollectionFn, storageCollectionConfig]);
 
   const searchIndex = useMemo(() => {
-    console.time("building search index");
     const searchIndex = new MiniSearch({
       fields: [
         "title",
@@ -112,7 +111,7 @@ export const CatalogFilteredCollectionList: React.FC<
     });
 
     searchIndex.addAll(datasetsToFilter);
-    console.timeEnd("building search index");
+
     return searchIndex;
   }, [datasetsToFilter]);
 

--- a/src/pages/Explore/components/ItemDetailPanel/index.tsx
+++ b/src/pages/Explore/components/ItemDetailPanel/index.tsx
@@ -1,9 +1,11 @@
+import { CSSProperties } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import {
+  getTheme,
   IStackItemStyles,
   Pivot,
   PivotItem,
   StackItem,
-  useTheme,
 } from "@fluentui/react";
 
 import ItemPreview from "../ItemPreview";
@@ -12,41 +14,18 @@ import HeaderCard from "./HeaderCard";
 import MetadataList from "./MetadataList";
 import AssetList from "./AssetList";
 import BackToListButton from "./BackToListButton";
-import { CSSProperties } from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback, { handleErrorBoundaryError } from "components/ErrorFallback";
 import { selectCurrentMosaic } from "pages/Explore/state/mosaicSlice";
 
 const ItemDetailPanel = () => {
-  const theme = useTheme();
   const item = useExploreSelector(s => s.detail.selectedItem);
   const { collection } = useExploreSelector(selectCurrentMosaic);
   const title = collection?.title;
 
-  const itemDetailStylesOuter: Partial<IStackItemStyles> = {
-    root: {
-      height: "100%",
-      overflowY: "auto",
-      overflowX: "clip",
-    },
-  };
-
-  const itemDetailStylesInner: CSSProperties = {
-    border: "1px solid",
-    borderColor: theme.palette.neutralLight,
-    borderRadius: 4,
-    marginRight: 3,
-  };
-
   const content = item ? (
     <div style={itemDetailStylesInner} data-cy="detail-dialog">
       <BackToListButton />
-      <div
-        style={{
-          minWidth: 400,
-          minHeight: 400,
-        }}
-      >
+      <div style={previewStyles}>
         <ItemPreview item={item} size={400} border="top" />
       </div>
       <HeaderCard collectionName={title} item={item} />
@@ -79,3 +58,24 @@ const ItemDetailPanel = () => {
 };
 
 export default ItemDetailPanel;
+
+const theme = getTheme();
+const itemDetailStylesOuter: Partial<IStackItemStyles> = {
+  root: {
+    height: "100%",
+    overflowY: "auto",
+    overflowX: "clip",
+  },
+};
+
+const itemDetailStylesInner: CSSProperties = {
+  border: "1px solid",
+  borderColor: theme.palette.neutralLight,
+  borderRadius: 4,
+  marginRight: 3,
+};
+
+const previewStyles: CSSProperties = {
+  minWidth: 400,
+  minHeight: 400,
+};

--- a/src/pages/Explore/components/ItemResult.tsx
+++ b/src/pages/Explore/components/ItemResult.tsx
@@ -47,9 +47,11 @@ const ItemResult = ({ item }: ItemResultProps) => {
         <div style={wrapperStyle}>
           <ItemPreview item={item} key={item.id} />
         </div>
-        <Stack verticalAlign={"space-evenly"} style={{ paddingRight: "10px" }}>
+        <Stack verticalAlign={"space-evenly"} style={{ paddingRight: 10 }}>
           <Text styles={idStyles}>{item.id}</Text>
-          <PriorityAttributes item={item} />
+          <div style={attributeStyle}>
+            <PriorityAttributes item={item} />
+          </div>
         </Stack>
       </Stack>
     </Link>
@@ -107,4 +109,8 @@ const idStyles = {
     fontWeight: "600",
     overflowWrap: "anywhere",
   },
+};
+
+const attributeStyle: CSSProperties = {
+  fontSize: 13,
 };

--- a/src/pages/Explore/components/Sidebar/panes/QueryInfo/QuerySection.tsx
+++ b/src/pages/Explore/components/Sidebar/panes/QueryInfo/QuerySection.tsx
@@ -7,7 +7,7 @@ import {
   CqlExpression,
   ICqlExpressionList,
 } from "pages/Explore/utils/cql/types";
-import { toUtcDateString } from "utils";
+import { formatDatetimeHuman } from "pages/Explore/utils/time";
 import { stacFormatter } from "utils/stac";
 import { opEnglish, operators } from "../../../query/constants";
 import Section from "./Section";
@@ -68,14 +68,18 @@ const getDateLabel = (
     const isSingleDate = rangeIsOnSameDay(value);
 
     const labelText = isSingleDate
-      ? `${propertyLabel} ${opEnglish[op]} ${toUtcDateString(value[0])} `
-      : `${propertyLabel} between ${toUtcDateString(value[0])} and ${toUtcDateString(
-          value[1]
-        )}`;
+      ? `${propertyLabel} ${opEnglish[op]} ${formatDatetimeHuman(value[0])} `
+      : `${propertyLabel} between ${formatDatetimeHuman(
+          value[0]
+        )} and ${formatDatetimeHuman(value[1])}`;
 
     return <Text>{labelText}</Text>;
-  } else if (property === "datetime" && !Array.isArray(value)) {
-    const labelText = `${propertyLabel} ${opEnglish[op]} ${toUtcDateString(value)}`;
+  }
+
+  if (property === "datetime") {
+    const labelText = `${propertyLabel} ${opEnglish[op]} ${formatDatetimeHuman(
+      value
+    )}`;
     return <Text>{labelText}</Text>;
   }
 };

--- a/src/pages/Explore/components/controls/IconValue.tsx
+++ b/src/pages/Explore/components/controls/IconValue.tsx
@@ -16,7 +16,7 @@ const IconValue = ({ iconName, title, value, iconSize = 20 }: IconValueProps) =>
   });
 
   return (
-    <Stack horizontal tokens={{ childrenGap: 8 }}>
+    <Stack horizontal tokens={{ childrenGap: 8 }} styles={containerStyles}>
       <span>{value} </span>
       <FontIcon
         title={title}
@@ -29,3 +29,9 @@ const IconValue = ({ iconName, title, value, iconSize = 20 }: IconValueProps) =>
 };
 
 export default IconValue;
+
+const containerStyles = {
+  root: {
+    fontSize: "inherit",
+  },
+};

--- a/src/pages/Explore/components/controls/PriorityAttributes.tsx
+++ b/src/pages/Explore/components/controls/PriorityAttributes.tsx
@@ -1,4 +1,4 @@
-import { Stack, StackItem, useTheme } from "@fluentui/react";
+import { getTheme, Stack, StackItem } from "@fluentui/react";
 import { isNumber } from "lodash-es";
 import { formatDatetimeHuman } from "pages/Explore/utils/time";
 
@@ -11,7 +11,6 @@ interface PriorityAttributesProps {
 
 // Show high-priority attributes if they exist
 const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
-  const theme = useTheme();
   const cloud = item.properties?.["eo:cloud_cover"];
 
   // Items typically have a datetime, if not, they'll have start_/end_datetime
@@ -24,7 +23,8 @@ const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
 
   const dtRangeTitle = hasRange && (
     <span title="Acquired between">
-      {formatDatetimeHuman(dateRange[0])} — {formatDatetimeHuman(dateRange[1])}
+      {formatDatetimeHuman(dateRange[0], false, true)} —{" "}
+      {formatDatetimeHuman(dateRange[1], false, true)}
     </span>
   );
 
@@ -37,15 +37,11 @@ const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
       horizontal
       horizontalAlign={"space-between"}
       tokens={{ childrenGap: 5 }}
-      styles={{
-        root: {
-          color: theme.palette.neutralSecondary,
-        },
-      }}
+      styles={containerStyles}
     >
       {dtTitle}
       {dtRangeTitle}
-      <StackItem styles={{ root: { paddingRight: 8 } }}>
+      <StackItem styles={cloudContainerStyles}>
         {isNumber(cloud) && (
           <IconValue
             iconName="Cloud"
@@ -59,3 +55,17 @@ const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
 };
 
 export default PriorityAttributes;
+
+const theme = getTheme();
+const containerStyles = {
+  root: {
+    color: theme.palette.neutralSecondary,
+  },
+};
+
+const cloudContainerStyles = {
+  root: {
+    paddingRight: 8,
+    fontSize: "inherit",
+  },
+};

--- a/src/pages/Explore/components/controls/PriorityAttributes.tsx
+++ b/src/pages/Explore/components/controls/PriorityAttributes.tsx
@@ -1,7 +1,7 @@
 import { Stack, StackItem, useTheme } from "@fluentui/react";
 import { isNumber } from "lodash-es";
+import { formatDatetimeHuman } from "pages/Explore/utils/time";
 
-import { toDateWithTime24, toUtcDateString } from "utils";
 import { IStacItem } from "types/stac";
 import IconValue from "./IconValue";
 
@@ -24,12 +24,12 @@ const PriorityAttributes = ({ item }: PriorityAttributesProps) => {
 
   const dtRangeTitle = hasRange && (
     <span title="Acquired between">
-      {toUtcDateString(dateRange[0])} — {toUtcDateString(dateRange[1])}
+      {formatDatetimeHuman(dateRange[0])} — {formatDatetimeHuman(dateRange[1])}
     </span>
   );
 
   const dtTitle = !hasRange && date && (
-    <span title="Acquisition date (UTC)">{toDateWithTime24(date)}</span>
+    <span title="Acquisition date (UTC)">{formatDatetimeHuman(date)}</span>
   );
 
   return (

--- a/src/pages/Explore/components/query/DateField/CalendarControl.tsx
+++ b/src/pages/Explore/components/query/DateField/CalendarControl.tsx
@@ -137,15 +137,11 @@ const CalendarControl = ({
 
   const handleDateChange = useCallback(
     (newDate: Date) => {
+      if (!date) return;
+
       // When the date has changed from the calendar, we need to apply the
       // existing time to the new date.
-      const newDatetime = parseDatetime(newDate)
-        .utc()
-        .hour(date?.hour() || 0)
-        .minute(date?.minute() || 0)
-        .second(date?.second() || 0)
-        .millisecond(date?.millisecond() || 0);
-
+      const newDatetime = adjustTime(newDate, date?.format("HH:mm:ss"));
       setSelectedDatetime(newDatetime.toDate());
     },
     [date, setSelectedDatetime]

--- a/src/pages/Explore/components/query/DateField/CalendarControl.tsx
+++ b/src/pages/Explore/components/query/DateField/CalendarControl.tsx
@@ -193,6 +193,8 @@ const CalendarControl = ({
     />
   );
 
+  const validTimeOperator = ["between", "before", "after"].includes(operator);
+
   return (
     <Stack styles={controlStyles}>
       <Label styles={labelStyles}>{label}</Label>
@@ -211,12 +213,16 @@ const CalendarControl = ({
         calendarDayProps={{ ...calendarDayProps, ...calDayNav }}
         calendarMonthProps={calendarMonthProps}
       />
-      <Separator styles={separatorStyles} />
-      <Time
-        time={date.utc().format("HH:mm:ss")}
-        rangeType={rangeType}
-        onChange={handleTimeChange}
-      />
+      {validTimeOperator && (
+        <>
+          <Separator styles={separatorStyles} />
+          <Time
+            time={date.utc().format("HH:mm:ss")}
+            rangeType={rangeType}
+            onChange={handleTimeChange}
+          />
+        </>
+      )}
       {errorMessage && (
         <MessageBar styles={errorMsgStyles} messageBarType={MessageBarType.error}>
           {errorMessage}

--- a/src/pages/Explore/components/query/DateField/DateField.tsx
+++ b/src/pages/Explore/components/query/DateField/DateField.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useState,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-} from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import {
   Stack,
   IStackTokens,
@@ -16,10 +9,8 @@ import {
   DirectionalHint,
   ISeparatorStyles,
   IStackStyles,
-  Link,
   TooltipHost,
   Text,
-  IButtonStyles,
 } from "@fluentui/react";
 
 import CalendarControl from "./CalendarControl";
@@ -54,14 +45,6 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
   const dispatch = useExploreDispatch();
   const panelRef = useRef<PanelControlHandlers>(null);
 
-  const [initialExpression, setInitialExpression] = useState<CqlDate>();
-
-  // Track initial state so we can determine if things have changed
-  useEffect(() => {
-    setInitialExpression(dateExpression);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const initialDateRange = useMemo(() => {
     return toDateRange(dateExpression);
   }, [dateExpression]);
@@ -79,8 +62,10 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
   const minDay = getDayStart(dateExpression.min, true);
   const maxDay = getDayEnd(dateExpression.max, true);
 
-  const { OperatorSelector, operatorSelection, resetOperatorSelection } =
-    useOperatorSelector(dateExpression, initialDateRange);
+  const { OperatorSelector, operatorSelection } = useOperatorSelector(
+    dateExpression,
+    initialDateRange
+  );
 
   const isValid = isValidToApply(
     controlValidState,
@@ -107,14 +92,6 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
     workingDates: workingDateRange,
     setValidation: validationDispatch,
     validationState: controlValidState,
-  };
-
-  const handleReset = () => {
-    if (!initialExpression) return;
-
-    resetOperatorSelection();
-    const drs = toDateRange(initialExpression);
-    workingDateRangeDispatch({ start: drs.start, end: drs.end });
   };
 
   const handleRenderText = () => {
@@ -160,9 +137,6 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
               horizontalAlign={"space-between"}
             >
               {OperatorSelector}
-              <Link styles={resetStyles} onClick={handleReset}>
-                Reset
-              </Link>
             </Stack>
             <Separator styles={separatorStyles} />
             <Stack horizontal tokens={calendarTokens}>
@@ -219,11 +193,5 @@ const dividerStyles: IVerticalDividerStyles = {
   divider: {
     height: "100%",
     backgroundColor: theme.palette.neutralLight,
-  },
-};
-
-const resetStyles: Partial<IButtonStyles> = {
-  root: {
-    display: "none",
   },
 };

--- a/src/pages/Explore/components/query/DateField/DateField.tsx
+++ b/src/pages/Explore/components/query/DateField/DateField.tsx
@@ -79,7 +79,6 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
   const handleSave = useCallback(() => {
     if (isValid) {
       const exp = toCqlExpression(workingDateRange, operatorSelection.key);
-      console.table(exp.args[1].interval);
       dispatch(setCustomCqlExpressions(exp));
     }
   }, [isValid, workingDateRange, operatorSelection.key, dispatch]);

--- a/src/pages/Explore/components/query/DateField/DateField.tsx
+++ b/src/pages/Explore/components/query/DateField/DateField.tsx
@@ -17,7 +17,7 @@ import CalendarControl from "./CalendarControl";
 import { CqlDate } from "pages/Explore/utils/cql/types";
 import { opEnglish } from "../constants";
 import { DateFieldProvider, IDateFieldContext } from "./context";
-import { capitalize, getDayEnd, getDayStart, toDateString } from "utils";
+import { capitalize } from "utils";
 import {
   getDateDisplayText,
   isSingleDayRange,
@@ -36,6 +36,7 @@ import { setCustomCqlExpressions } from "pages/Explore/state/mosaicSlice";
 import { DropdownButton } from "../DropdownButton";
 import { PanelControlHandlers } from "pages/Explore/components/Map/components/PanelControl";
 import DropdownLabel from "../components/DropdownLabel";
+import { formatDateShort, getDayEnd, getDayStart } from "pages/Explore/utils/time";
 
 interface DateFieldProps {
   dateExpression: CqlDate;
@@ -59,8 +60,8 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
     initialValidationState
   );
 
-  const minDay = getDayStart(dateExpression.min, true);
-  const maxDay = getDayEnd(dateExpression.max, true);
+  const minDay = getDayStart(dateExpression.min);
+  const maxDay = getDayEnd(dateExpression.max);
 
   const { OperatorSelector, operatorSelection } = useOperatorSelector(
     dateExpression,
@@ -78,6 +79,7 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
   const handleSave = useCallback(() => {
     if (isValid) {
       const exp = toCqlExpression(workingDateRange, operatorSelection.key);
+      console.table(exp.args[1].interval);
       dispatch(setCustomCqlExpressions(exp));
     }
   }, [isValid, workingDateRange, operatorSelection.key, dispatch]);
@@ -110,10 +112,12 @@ export const DateField = ({ dateExpression }: DateFieldProps) => {
     handleSave();
   }, [handleSave, workingDateRange, operatorSelection.key]);
 
-  const disabled = isSingleDayRange(initialDateRange);
+  const disabled = isSingleDayRange(dateExpression);
   const disabledMsg = disabled ? (
     <Text>
-      <Text style={{ fontWeight: 500 }}>{toDateString(initialDateRange.start)}</Text>{" "}
+      <Text style={{ fontWeight: 500 }}>
+        {formatDateShort(initialDateRange.start)}
+      </Text>{" "}
       is the only date available for this dataset
     </Text>
   ) : (

--- a/src/pages/Explore/components/query/DateField/Time.tsx
+++ b/src/pages/Explore/components/query/DateField/Time.tsx
@@ -4,12 +4,11 @@ import {
   ITextField,
   ITextFieldStyles,
   ITextStyles,
-  MaskedTextField,
   Stack,
   Text,
   TextField,
 } from "@fluentui/react";
-import { createRef, useRef } from "react";
+import { createRef } from "react";
 import { RangeType } from "./types";
 
 interface TimeProps {

--- a/src/pages/Explore/components/query/DateField/Time.tsx
+++ b/src/pages/Explore/components/query/DateField/Time.tsx
@@ -1,0 +1,75 @@
+import {
+  IStackStyles,
+  IStackTokens,
+  ITextField,
+  ITextFieldStyles,
+  ITextStyles,
+  MaskedTextField,
+  Stack,
+  Text,
+  TextField,
+} from "@fluentui/react";
+import { createRef, useRef } from "react";
+import { RangeType } from "./types";
+
+interface TimeProps {
+  time: string;
+  onChange: (value: string) => void;
+  rangeType: RangeType;
+}
+
+const defaultStart = "00:00:00Z";
+const defaultEnd = "23:59:59Z";
+
+export const Time: React.FC<TimeProps> = ({ time, rangeType, onChange }) => {
+  const defaultTime = rangeType === "start" ? defaultStart : defaultEnd;
+  const ref = createRef<ITextField>();
+
+  const handleChange = (
+    _: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+    newValue?: string | undefined
+  ): void => {
+    onChange(ref.current?.value || defaultTime);
+  };
+
+  return (
+    <Stack
+      styles={containerStyles}
+      tokens={containerTokens}
+      horizontal
+      verticalAlign="center"
+    >
+      <Text styles={textStyles}>Time (UTC)</Text>
+      <TextField
+        componentRef={ref}
+        styles={inputStyles}
+        defaultValue={time}
+        onBlur={handleChange}
+      />
+    </Stack>
+  );
+};
+
+const containerTokens: IStackTokens = {
+  childrenGap: 4,
+};
+
+const containerStyles: IStackStyles = {
+  root: {
+    margin: 4,
+    marginLeft: 8,
+    marginTop: 0,
+  },
+};
+
+const textStyles: ITextStyles = {
+  root: {
+    fontWeight: 600,
+  },
+};
+
+const inputStyles: Partial<ITextFieldStyles> = {
+  root: {
+    width: 125,
+  },
+};

--- a/src/pages/Explore/components/query/DateField/context.tsx
+++ b/src/pages/Explore/components/query/DateField/context.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import dayjs, { Dayjs } from "dayjs";
+import { Dayjs } from "dayjs";
 import { DateRangeState, ValidationAction, ValidationState } from "./types";
 import { initialValidationState } from "./state";
+import { parseDatetime } from "pages/Explore/utils/time";
 
 export interface IDateFieldContext {
   validMinDate: Dayjs;
@@ -13,10 +14,11 @@ export interface IDateFieldContext {
     | ((arg: ValidationAction) => void);
 }
 
+const now = parseDatetime(new Date());
 export const DateFieldContext = React.createContext<IDateFieldContext>({
-  validMinDate: dayjs(),
-  validMaxDate: dayjs(),
-  workingDates: { start: dayjs(), end: null },
+  validMinDate: now,
+  validMaxDate: now,
+  workingDates: { start: now, end: null },
   setValidation: () => {},
   validationState: initialValidationState,
 });

--- a/src/pages/Explore/components/query/DateField/helpers.tsx
+++ b/src/pages/Explore/components/query/DateField/helpers.tsx
@@ -11,6 +11,7 @@ import {
   formatDatetime,
   formatDatetimeHuman,
   getDayEnd,
+  getDayStart,
   parseDatetime,
 } from "pages/Explore/utils/time";
 import { dayjs } from "utils";
@@ -29,8 +30,8 @@ export const getEndRangeValue = (date: CqlDate): Dayjs => {
 
 export const getDateDisplayText = (dateExpression: CqlDate) => {
   return dateExpression.isRange
-    ? dateExpression.value.map(v => formatDatetimeHuman(v, true)).join(" – ")
-    : formatDatetimeHuman(dateExpression.value, true);
+    ? dateExpression.value.map(v => formatDatetimeHuman(v, true, true)).join(" – ")
+    : formatDatetimeHuman(dateExpression.value, true, true);
 };
 
 export const isSingleDayRange = (dateExpression: CqlDate): boolean => {
@@ -105,6 +106,7 @@ export const toCqlExpression = (
   const property: CqlPropertyObject = { property: "datetime" };
 
   const start = formatDatetime(dateRange.start);
+  const startOfStartingDay = formatDatetime(getDayStart(dateRange.start));
   const endOfStartingDay = formatDatetime(getDayEnd(dateRange.start));
   const end = dateRange.end ? formatDatetime(dateRange.end) : undefined;
 
@@ -119,7 +121,7 @@ export const toCqlExpression = (
     case "on":
       return {
         op: "anyinteracts",
-        args: [property, { interval: [start, endOfStartingDay] }],
+        args: [property, { interval: [startOfStartingDay, endOfStartingDay] }],
       };
     case "after":
       return {

--- a/src/pages/Explore/components/query/DateField/state.ts
+++ b/src/pages/Explore/components/query/DateField/state.ts
@@ -1,4 +1,4 @@
-import { dayjs } from "utils";
+import { parseDatetime } from "pages/Explore/utils/time";
 import {
   DateRangeAction,
   DateRangeState,
@@ -20,9 +20,10 @@ export const validationReducer = (
   return { ...state, ...action };
 };
 
+const now = parseDatetime(new Date());
 export const initialWorkingDateState: DateRangeState = {
-  start: dayjs(),
-  end: dayjs(),
+  start: now,
+  end: now,
 };
 
 export const dateRangeReducer = (

--- a/src/pages/Explore/utils/cql/CqlParser.ts
+++ b/src/pages/Explore/utils/cql/CqlParser.ts
@@ -1,7 +1,7 @@
 import { JSONSchema } from "@apidevtools/json-schema-ref-parser";
 import { IStacCollection } from "types/stac";
 import { rangeFromTemporalExtent } from "../stac";
-import { formatDatetime } from "../time";
+import { formatDatetime, getDayEnd, getDayStart, parseDatetime } from "../time";
 import { CqlExpressionParser } from "./CqlExpressionParser";
 import { rangeIsOnSameDay } from "./helpers";
 
@@ -30,7 +30,16 @@ export class CqlParser {
   }
 
   private formatRange(range: CqlDateRange): CqlDateRange {
-    return [formatDatetime(range[0]), formatDatetime(range[1])];
+    const start = parseDatetime(range[0]);
+    const end = parseDatetime(range[1]);
+
+    // If the range is the same exact datetime, and at the begining of the day,
+    // expand it to a full day. This is the case of some single-day collections.
+    if (start.isSame(end) && start.isSame(getDayStart(start))) {
+      return [formatDatetime(start), formatDatetime(getDayEnd(end))];
+    }
+
+    return [formatDatetime(start), formatDatetime(end)];
   }
 
   getExpressions({

--- a/src/pages/Explore/utils/cql/CqlParser.ts
+++ b/src/pages/Explore/utils/cql/CqlParser.ts
@@ -1,6 +1,6 @@
 import { JSONSchema } from "@apidevtools/json-schema-ref-parser";
 import { IStacCollection } from "types/stac";
-import { toUtcDateString } from "utils";
+import { toDateWithTime24, toUtcDateString } from "utils";
 import { rangeFromTemporalExtent } from "../stac";
 import { CqlExpressionParser } from "./CqlExpressionParser";
 import { rangeIsOnSameDay } from "./helpers";
@@ -30,7 +30,7 @@ export class CqlParser {
   }
 
   private formatRange(range: CqlDateRange): CqlDateRange {
-    return [toUtcDateString(range[0]), toUtcDateString(range[1])];
+    return [toDateWithTime24(range[0]), toDateWithTime24(range[1])];
   }
 
   getExpressions({

--- a/src/pages/Explore/utils/cql/CqlParser.ts
+++ b/src/pages/Explore/utils/cql/CqlParser.ts
@@ -1,7 +1,7 @@
 import { JSONSchema } from "@apidevtools/json-schema-ref-parser";
 import { IStacCollection } from "types/stac";
-import { toDateWithTime24, toUtcDateString } from "utils";
 import { rangeFromTemporalExtent } from "../stac";
+import { formatDatetime } from "../time";
 import { CqlExpressionParser } from "./CqlExpressionParser";
 import { rangeIsOnSameDay } from "./helpers";
 
@@ -30,7 +30,7 @@ export class CqlParser {
   }
 
   private formatRange(range: CqlDateRange): CqlDateRange {
-    return [toDateWithTime24(range[0]), toDateWithTime24(range[1])];
+    return [formatDatetime(range[0]), formatDatetime(range[1])];
   }
 
   getExpressions({
@@ -77,7 +77,7 @@ export class CqlParser {
         const implicitDate = date.value[0];
         return {
           operator: date.operator,
-          value: toUtcDateString(implicitDate),
+          value: formatDatetime(implicitDate),
           isRange: false,
           ...collectionRange,
         };
@@ -86,7 +86,7 @@ export class CqlParser {
 
     return {
       operator: date.operator,
-      value: toUtcDateString(date.value),
+      value: formatDatetime(date.value),
       isRange: false,
       ...collectionRange,
     };

--- a/src/pages/Explore/utils/cql/helpers/index.ts
+++ b/src/pages/Explore/utils/cql/helpers/index.ts
@@ -32,7 +32,6 @@ export const rangeIsOnSameDay = (
     date1.format("HH:mm:ss") === "00:00:00" &&
     date2.format("HH:mm:ss") === "23:59:59";
 
-  return isSameDay;
   return isSameDay && isFullDayRange;
 };
 

--- a/src/pages/Explore/utils/cql/helpers/index.ts
+++ b/src/pages/Explore/utils/cql/helpers/index.ts
@@ -24,7 +24,16 @@ export const rangeIsOnSameDay = (
 
   const [date1, date2] = dateExpressionValue.map(d => dayjs.utc(d));
 
-  return date1.isSame(date2, "day");
+  // Date range is same calendar day?
+  const isSameDay = date1.isSame(date2, "day");
+
+  // Within calendar day, do the times represent a full day?
+  const isFullDayRange =
+    date1.format("HH:mm:ss") === "00:00:00" &&
+    date2.format("HH:mm:ss") === "23:59:59";
+
+  return isSameDay;
+  return isSameDay && isFullDayRange;
 };
 
 // CQL expression lists that come from a restored searchId (i.e., from the query string)

--- a/src/pages/Explore/utils/stac.ts
+++ b/src/pages/Explore/utils/stac.ts
@@ -4,7 +4,7 @@ import { BBox } from "geojson";
 
 import { IStacCollection, IStacFilterCollection, IStacFilterGeom } from "types/stac";
 import { CqlDateRange } from "./cql/types";
-import { dayjs, toIsoDateString } from "utils";
+import { formatDatetime, getDayEnd } from "./time";
 
 export const collectionFilter = (
   collectionId: string | undefined
@@ -36,10 +36,10 @@ export const geomFilter = (
 export const rangeFromTemporalExtent = (
   interval: IStacCollection["extent"]["temporal"]["interval"]
 ): CqlDateRange => {
-  const today = toIsoDateString(new Date());
+  const today = formatDatetime(new Date());
 
   const start = interval[0][0] || today;
-  const end = interval[0][1] || toIsoDateString(dayjs().endOf("day"));
+  const end = interval[0][1] || formatDatetime(getDayEnd(new Date()));
 
   return [start, end];
 };

--- a/src/pages/Explore/utils/stac.ts
+++ b/src/pages/Explore/utils/stac.ts
@@ -4,6 +4,7 @@ import { BBox } from "geojson";
 
 import { IStacCollection, IStacFilterCollection, IStacFilterGeom } from "types/stac";
 import { CqlDateRange } from "./cql/types";
+import { dayjs, toIsoDateString } from "utils";
 
 export const collectionFilter = (
   collectionId: string | undefined
@@ -35,7 +36,10 @@ export const geomFilter = (
 export const rangeFromTemporalExtent = (
   interval: IStacCollection["extent"]["temporal"]["interval"]
 ): CqlDateRange => {
-  const start = interval[0][0] || new Date().toUTCString();
-  const end = interval[0][1] || new Date().toUTCString();
+  const today = toIsoDateString(new Date());
+
+  const start = interval[0][0] || today;
+  const end = interval[0][1] || toIsoDateString(dayjs().endOf("day"));
+
   return [start, end];
 };

--- a/src/pages/Explore/utils/time.test.ts
+++ b/src/pages/Explore/utils/time.test.ts
@@ -1,0 +1,35 @@
+import {
+  adjustTime,
+  formatDatetime,
+  getDayEnd,
+  getDayStart,
+  parseDatetime,
+} from "./time";
+
+test("Parse and format new date", () => {
+  const date = new Date("2020-01-01");
+  expect(formatDatetime(parseDatetime(date))).toEqual("2020-01-01T00:00:00Z");
+});
+
+test("Parse and format date string with time", () => {
+  const date = "2020-01-01 19:00:00Z";
+  expect(formatDatetime(parseDatetime(date))).toEqual("2020-01-01T19:00:00Z");
+});
+
+test("Adjust time of date", () => {
+  const date = new Date("2020-01-01");
+  const adjusted = adjustTime(date, "19:00:00");
+  expect(formatDatetime(adjusted)).toEqual("2020-01-01T19:00:00Z");
+});
+
+test("Get start of day", () => {
+  const date = new Date("2020-01-01");
+  const d = getDayStart(date);
+  expect(formatDatetime(d)).toEqual("2020-01-01T00:00:00Z");
+});
+
+test("Get end of day", () => {
+  const date = new Date("2020-01-01");
+  const d = getDayEnd(date);
+  expect(formatDatetime(d)).toEqual("2020-01-01T23:59:59Z");
+});

--- a/src/pages/Explore/utils/time.ts
+++ b/src/pages/Explore/utils/time.ts
@@ -1,0 +1,43 @@
+import { Dayjs } from "dayjs";
+import { dayjs } from "utils";
+
+// Time utilities
+
+export const parseDatetime = (date: Date | string | Dayjs) => {
+  return dayjs(date).utc();
+};
+
+export const formatDatetime = (date: Date | string | Dayjs) => {
+  const d = parseDatetime(date);
+  return d.format();
+};
+
+export const formatDateShort = (date: Date | string | Dayjs) => {
+  const d = parseDatetime(date);
+  return d.format("YYYY-MM-DD");
+};
+
+export const formatDatetimeHuman = (
+  date: Date | string | Dayjs,
+  short: boolean | undefined = false
+) => {
+  const d = parseDatetime(date);
+  const timeFormat = short ? "HH:mm" : ", HH:mm:ss";
+  return d.format(`L ${timeFormat}`);
+};
+
+export const adjustTime = (date: Date | string | Dayjs, time: string) => {
+  const d = parseDatetime(date);
+  const [hours, minutes, seconds] = time.split(":").map(Number);
+  return d.hour(hours).minute(minutes).second(seconds);
+};
+
+export const getDayStart = (date: string | Date | Dayjs) => {
+  const d = parseDatetime(date);
+  return d.startOf("day");
+};
+
+export const getDayEnd = (date: string | Date | Dayjs) => {
+  const d = parseDatetime(date);
+  return d.endOf("day");
+};

--- a/src/pages/Explore/utils/time.ts
+++ b/src/pages/Explore/utils/time.ts
@@ -14,16 +14,27 @@ export const formatDatetime = (date: Date | string | Dayjs) => {
 
 export const formatDateShort = (date: Date | string | Dayjs) => {
   const d = parseDatetime(date);
-  return d.format("YYYY-MM-DD");
+  return d.format("MM/DD/YYYY");
 };
 
 export const formatDatetimeHuman = (
   date: Date | string | Dayjs,
-  short: boolean | undefined = false
+  forceShort: boolean | undefined = false,
+  shortenIfBoundaryTime: boolean | undefined = false
 ) => {
   const d = parseDatetime(date);
-  const timeFormat = short ? "HH:mm" : ", HH:mm:ss";
-  return d.format(`L ${timeFormat}`);
+  const dayBoundary =
+    d.format("HH:mm:ss") === "00:00:00" || d.format("HH:mm:ss") === "23:59:59";
+
+  if (dayBoundary && shortenIfBoundaryTime) {
+    return formatDateShort(d);
+  }
+
+  if (forceShort) {
+    return d.format(`MM/DD/YYYY HH:mm`);
+  }
+
+  return d.format(`MM/DD/YYYY HH:mm:ss UTC`);
 };
 
 export const adjustTime = (date: Date | string | Dayjs, time: string) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ export const toDateString = (
   includeTime: boolean = false
 ) => {
   const dateFormat = "MM/DD/YYYY";
-  const timeFormat = includeTime ? "THH:mm:ss" : "";
+  const timeFormat = includeTime ? "THH:mm:ss[Z]" : "";
 
   return dayjs(dt).format(dateFormat + timeFormat);
 };
@@ -34,7 +34,7 @@ export const toUtcDateWithTime = (dt: string) =>
   dayjs.utc(dt).format("MM/DD/YYYY, h:mm:ss A UTC");
 
 export const toDateWithTime24 = (dt: string) =>
-  dayjs.utc(dt).format("MM/DD/YYYY, HH:mm:ss");
+  dayjs.utc(dt).format("MM/DD/YYYY, HH:mm:ss[Z]");
 
 export const toIsoDateString = (
   dt: string | Date | Dayjs,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,6 @@ import { DATA_URL, HUB_URL, QS_REQUEST_ENTITY, REQUEST_ENTITY } from "./constant
 import * as qs from "query-string";
 import { IMosaic, IMosaicRenderOption } from "pages/Explore/types";
 import { DEFAULT_MIN_ZOOM } from "pages/Explore/utils/constants";
-// import { useSession } from "components/auth/hooks/SessionContext";
 
 dayjs.extend(utc);
 export { dayjs };
@@ -14,52 +13,6 @@ export { dayjs };
 // The represented date without consideration for the timezone
 export const toAbsoluteDate = (date: Dayjs) => {
   return new Date(date.year(), date.month(), date.date());
-};
-
-export const toDateString = (
-  dt: string | Date | Dayjs,
-  includeTime: boolean = false
-) => {
-  const dateFormat = "MM/DD/YYYY";
-  const timeFormat = includeTime ? "THH:mm:ss[Z]" : "";
-
-  return dayjs(dt).format(dateFormat + timeFormat);
-};
-
-export const toUtcDateString = (dt: string | Date | Dayjs) => {
-  return toDateString(dayjs.utc(dt));
-};
-
-export const toUtcDateWithTime = (dt: string) =>
-  dayjs.utc(dt).format("MM/DD/YYYY, h:mm:ss A UTC");
-
-export const toDateWithTime24 = (dt: string) =>
-  dayjs.utc(dt).format("MM/DD/YYYY, HH:mm:ss[Z]");
-
-export const toIsoDateString = (
-  dt: string | Date | Dayjs,
-  includeTime: boolean = true
-) => {
-  const dateFormat = "YYYY-MM-DD";
-  const timeFormat = includeTime ? "[T]HH:mm:ss[Z]" : "";
-
-  return dayjs(dt).format(dateFormat + timeFormat);
-};
-
-export const getDayStart = (
-  date: string | Date | Dayjs | undefined,
-  fromUtc: boolean = false
-) => {
-  const d = fromUtc ? dayjs.utc(date) : dayjs(date);
-  return d.startOf("day");
-};
-
-export const getDayEnd = (
-  date: string | Date | Dayjs | undefined,
-  fromUtc: boolean = false
-) => {
-  const d = fromUtc ? dayjs.utc(date) : dayjs(date);
-  return d.endOf("day");
 };
 
 export const capitalize = (value: string) => {

--- a/src/utils/stac.js
+++ b/src/utils/stac.js
@@ -11,12 +11,13 @@ import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { isEmpty, isNil, isObject } from "lodash-es";
 
-import { capitalize, toUtcDateWithTime } from ".";
+import { capitalize } from "utils";
 import NewTabLink from "../components/controls/NewTabLink";
 import SimpleKeyValueList from "../components/controls/SimpleKeyValueList";
 import Revealer from "../components/Revealer";
 import AssetDetails from "components/stac/AssetDetails";
 import NamedEntry from "components/controls/NamedEntry";
+import { formatDatetime } from "pages/Explore/utils/time";
 
 const stringList = value => {
   return Array.isArray(value) ? value.map(capitalize).join(", ") : capitalize(value);
@@ -42,7 +43,7 @@ StacFields.Registry.addAssetField("roles", {
 });
 
 StacFields.Registry.addMetadataField("datetime", {
-  formatter: value => (value ? toUtcDateWithTime(value) : "n/a"),
+  formatter: value => (value ? formatDatetime(value) : "n/a"),
 });
 
 StacFields.Registry.addMetadataField("gsd", {

--- a/src/utils/stac.js
+++ b/src/utils/stac.js
@@ -17,7 +17,7 @@ import SimpleKeyValueList from "../components/controls/SimpleKeyValueList";
 import Revealer from "../components/Revealer";
 import AssetDetails from "components/stac/AssetDetails";
 import NamedEntry from "components/controls/NamedEntry";
-import { formatDatetime } from "pages/Explore/utils/time";
+import { formatDatetimeHuman } from "pages/Explore/utils/time";
 
 const stringList = value => {
   return Array.isArray(value) ? value.map(capitalize).join(", ") : capitalize(value);
@@ -43,7 +43,7 @@ StacFields.Registry.addAssetField("roles", {
 });
 
 StacFields.Registry.addMetadataField("datetime", {
-  formatter: value => (value ? formatDatetime(value) : "n/a"),
+  formatter: value => (value ? formatDatetimeHuman(value) : "n/a"),
 });
 
 StacFields.Registry.addMetadataField("gsd", {


### PR DESCRIPTION
Adds UTC time display to most datetime or start/end ranges for items. Also threads time-inputs from the advanced DateField filter control to the appropriate STAC searches.