### PR TITLE
Add datetime sort option to search results

### DIFF
--- a/cypress/e2e/explorer/url_state.cy.js
+++ b/cypress/e2e/explorer/url_state.cy.js
@@ -60,6 +60,34 @@ describe("URL state is loaded to Explorer", () => {
     cy.contains("matched your filter");
   });
 
+  it("can specify a sort direction", () => {
+    cy.intercept("/api/stac/v1/collections/sentinel-2-l2a").as("getS2");
+    cy.intercept("/api/data/v1/mosaic/info?collection=sentinel-2-l2a").as(
+      "getS2mosaic"
+    );
+    cy.intercept("/api/stac/v1/search").as("getS2search");
+
+    cy.visit({
+      url: "/explore",
+      qs: {
+        d: "sentinel-2-l2a",
+        m: "Dec – Feb, 2022 (low cloud)",
+        r: "Color infrared",
+        ae: "0",
+        sr: "asc",
+      },
+    });
+
+    cy.wait(["@getS2", "@getS2mosaic"]);
+
+    cy.wait(["@getS2search"]);
+    cy.contains("matched your filter");
+
+    cy.getBySel("explore-results-menu-button").click();
+    cy.contains("Sort order").click();
+    cy.get("[title='Show oldest results first']").should("have.class", "is-checked");
+  });
+
   it("can specify a custom searchid", () => {
     cy.intercept("/api/stac/v1/collections/sentinel-2-l2a").as("getS2");
     cy.intercept("/api/data/v1/mosaic/info?collection=sentinel-2-l2a").as(
@@ -90,7 +118,7 @@ describe("URL state is loaded to Explorer", () => {
     cy.contains("matched your filter");
   });
 
-  it("can specify a multiple layers", () => {
+  it("can specify multiple layers", () => {
     cy.intercept("/api/stac/v1/collections/nasadem").as("getnasadem");
     cy.intercept("/api/stac/v1/collections/chloris-biomass").as("getchloris");
 

--- a/src/pages/Explore/components/Sidebar/panes/SearchResults/SearchResultHeaderMenu.tsx
+++ b/src/pages/Explore/components/Sidebar/panes/SearchResults/SearchResultHeaderMenu.tsx
@@ -1,5 +1,10 @@
-import { IButtonStyles, IconButton } from "@fluentui/react";
-import { useConst, useId, useBoolean } from "@fluentui/react-hooks";
+import {
+  ContextualMenuItemType,
+  IButtonStyles,
+  IconButton,
+  IContextualMenuProps,
+} from "@fluentui/react";
+import { useId, useBoolean } from "@fluentui/react-hooks";
 import { SidebarPanels } from "pages/Explore/enums";
 
 import { useExploreDispatch, useExploreSelector } from "pages/Explore/state/hooks";
@@ -7,15 +12,22 @@ import { setSidebarPanel } from "pages/Explore/state/mapSlice";
 import { selectCurrentMosaic } from "pages/Explore/state/mosaicSlice";
 import { isValidCollection } from "../../exporters/AnimationExporter/helpers";
 import QueryInfo from "../QueryInfo";
+import { useSortMenuItem } from "./useSortMenuItem";
 
 export const SearchResultHeaderMenu: React.FC = () => {
   const dispatch = useExploreDispatch();
   const { collection } = useExploreSelector(selectCurrentMosaic);
   const [isQueryInfoVisible, { toggle }] = useBoolean(false);
+  const sortItem = useSortMenuItem();
   const buttonId = useId("explore-results-menu-button");
 
-  const menuProps = useConst({
+  const menuProps: IContextualMenuProps = {
     items: [
+      sortItem,
+      {
+        key: "separator1",
+        itemType: ContextualMenuItemType.Divider,
+      },
       {
         key: "details",
         text: "Filter details",
@@ -34,6 +46,11 @@ export const SearchResultHeaderMenu: React.FC = () => {
             "_blank"
           );
         },
+      },
+      {
+        key: "exports",
+        text: "Export",
+        itemType: ContextualMenuItemType.Divider,
       },
       {
         key: "animate",
@@ -56,7 +73,7 @@ export const SearchResultHeaderMenu: React.FC = () => {
         disabled: isValidCollection(collection),
       },
     ],
-  });
+  };
 
   return (
     <>

--- a/src/pages/Explore/components/Sidebar/panes/SearchResults/useSortMenuItem.tsx
+++ b/src/pages/Explore/components/Sidebar/panes/SearchResults/useSortMenuItem.tsx
@@ -1,0 +1,57 @@
+import { IContextualMenuItem } from "@fluentui/react";
+import { useExploreDispatch, useExploreSelector } from "pages/Explore/state/hooks";
+
+import {
+  selectCurrentMosaic,
+  setMosaicQuery,
+} from "pages/Explore/state/mosaicSlice";
+import { IMosaic, ISortDir } from "pages/Explore/types";
+
+export const useSortMenuItem = (): IContextualMenuItem => {
+  const dispatch = useExploreDispatch();
+  const { query } = useExploreSelector(selectCurrentMosaic);
+
+  const clickHandler = (dir: ISortDir) => {
+    return (
+      e:
+        | React.MouseEvent<HTMLElement, MouseEvent>
+        | React.KeyboardEvent<HTMLElement>
+        | undefined
+    ) => {
+      const updatedMosaic: IMosaic = {
+        ...query,
+        sortby: dir,
+      };
+      dispatch(setMosaicQuery(updatedMosaic));
+      e?.preventDefault();
+    };
+  };
+
+  return {
+    key: "sortby",
+    text: "Sort order",
+    iconProps: { iconName: "Sort" },
+    subMenuProps: {
+      items: [
+        {
+          key: "sortby-date",
+          text: "Date descending",
+          title: "Show newest results first",
+          iconProps: { iconName: "SortDown" },
+          canCheck: true,
+          checked: !query.sortby || query.sortby === "desc",
+          onClick: clickHandler("desc"),
+        },
+        {
+          key: "sortby-date-asc",
+          text: "Date ascending",
+          title: "Show oldest results first",
+          iconProps: { iconName: "SortUp" },
+          canCheck: true,
+          checked: query.sortby === "asc",
+          onClick: clickHandler("asc"),
+        },
+      ],
+    },
+  };
+};

--- a/src/pages/Explore/components/Sidebar/panes/SearchResults/useSortMenuItem.tsx
+++ b/src/pages/Explore/components/Sidebar/panes/SearchResults/useSortMenuItem.tsx
@@ -31,12 +31,14 @@ export const useSortMenuItem = (): IContextualMenuItem => {
     key: "sortby",
     text: "Sort order",
     iconProps: { iconName: "Sort" },
+    "data-cy": "sortby",
     subMenuProps: {
       items: [
         {
-          key: "sortby-date",
+          key: "sortby-date-desc",
           text: "Date descending",
           title: "Show newest results first",
+          "data-cy": "sortby-desc",
           iconProps: { iconName: "SortDown" },
           canCheck: true,
           checked: !query.sortby || query.sortby === "desc",

--- a/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
@@ -1,6 +1,6 @@
 import { isNumber } from "lodash-es";
 import { useExploreSelector } from "pages/Explore/state/hooks";
-import { ILayerState } from "pages/Explore/types";
+import { CurrentLayers, ILayerState } from "pages/Explore/types";
 import { updateQueryStringParam } from "pages/Explore/utils";
 import { useCallback, useEffect } from "react";
 
@@ -9,6 +9,7 @@ export const QS_CUSTOM_PREFIX = "cql:";
 export const QS_COLLECTION_KEY = "d";
 export const QS_MOSAIC_KEY = "m";
 export const QS_RENDER_KEY = "r";
+export const QS_SORT_KEY = "sr";
 export const QS_SETTINGS_KEY = "s";
 export const QS_ACTIVE_EDIT_KEY = "ae";
 export const QS_VERSION_KEY = "v";
@@ -76,12 +77,25 @@ export const useUrlStateV2 = () => {
     [currentEditingLayerId]
   );
 
+  const setSortQs = useCallback(
+    (layers: CurrentLayers) => {
+      if (currentEditingLayerId) {
+        updateQueryStringParam(
+          QS_SORT_KEY,
+          layers[currentEditingLayerId]?.query.sortby
+        );
+      }
+    },
+    [currentEditingLayerId]
+  );
+
   useEffect(() => {
     setCollectionQs(orderedLayers);
     setMosiacQs(orderedLayers);
     setRenderQs(orderedLayers);
     setLayerSettingsQs(orderedLayers);
     setLayerEditingQs(orderedLayers);
+    setSortQs(layers);
   }, [
     layers,
     orderedLayers,
@@ -90,6 +104,7 @@ export const useUrlStateV2 = () => {
     setLayerSettingsQs,
     setMosiacQs,
     setRenderQs,
+    setSortQs,
   ]);
 };
 

--- a/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/hooks/useUrlStateV2.tsx
@@ -1,6 +1,6 @@
 import { isNumber } from "lodash-es";
 import { useExploreSelector } from "pages/Explore/state/hooks";
-import { CurrentLayers, ILayerState } from "pages/Explore/types";
+import { ILayerState } from "pages/Explore/types";
 import { updateQueryStringParam } from "pages/Explore/utils";
 import { useCallback, useEffect } from "react";
 
@@ -77,17 +77,11 @@ export const useUrlStateV2 = () => {
     [currentEditingLayerId]
   );
 
-  const setSortQs = useCallback(
-    (layers: CurrentLayers) => {
-      if (currentEditingLayerId) {
-        updateQueryStringParam(
-          QS_SORT_KEY,
-          layers[currentEditingLayerId]?.query.sortby
-        );
-      }
-    },
-    [currentEditingLayerId]
-  );
+  const setSortQs = useCallback((ol: ILayerState[]) => {
+    const sorts = ol.map(l => l.query.sortby || "desc").join(QS_SEPARATOR);
+
+    updateQueryStringParam(QS_SORT_KEY, sorts);
+  }, []);
 
   useEffect(() => {
     setCollectionQs(orderedLayers);
@@ -95,7 +89,7 @@ export const useUrlStateV2 = () => {
     setRenderQs(orderedLayers);
     setLayerSettingsQs(orderedLayers);
     setLayerEditingQs(orderedLayers);
-    setSortQs(layers);
+    setSortQs(orderedLayers);
   }, [
     layers,
     orderedLayers,

--- a/src/pages/Explore/state/inititalStateHelper.ts
+++ b/src/pages/Explore/state/inititalStateHelper.ts
@@ -163,11 +163,16 @@ const loadMosaicStateV2 = async (
         throw new Error("Invalid mosaic or render option");
       }
 
+      // Check the sort for this layer as specified in the query string. If this ends up
+      // being a custom query, we'll use the sort that was included in the stac search
+      const qsSort = sortDirs[index] || "desc";
+
       // Register the cql to get the search Id, custom queries don't have
-      // cql but already have a searchId
+      // cql but already have a searchId.
+      const sortedMosaic = { ...mosaic, sortby: qsSort };
       const searchId = isCustomQuery
         ? customSearchId
-        : await registerStacFilter(collection.id, mosaic, mosaic.cql, false);
+        : await registerStacFilter(collection.id, sortedMosaic, mosaic.cql, false);
 
       // Get the named mosaic's cql, or fetch the cql for a custom query's searchId
       const customQueryMetadata = isCustomQuery
@@ -180,7 +185,7 @@ const loadMosaicStateV2 = async (
 
       const sortby = customQueryMetadata
         ? parseSortBy(customQueryMetadata.search.search.sortby)
-        : sortDirs[index] || "desc";
+        : qsSort;
 
       // The registered cql will have had the collection id property added
       // which we don't need. It's stored directly on the state.

--- a/src/pages/Explore/state/inititalStateHelper.ts
+++ b/src/pages/Explore/state/inititalStateHelper.ts
@@ -62,7 +62,7 @@ const loadQsV1 = (
       [collectionId],
       [mosaicName],
       [renderOptionName],
-      "desc",
+      ["desc"],
       [],
       undefined,
       dispatch
@@ -78,7 +78,7 @@ const loadQsV2 = (dispatch: ThunkDispatch<unknown, unknown, AnyAction>) => {
   const collectionIds = qs.get(QS_COLLECTION_KEY)?.split(QS_SEPARATOR) ?? [];
   const mosaicNames = qs.get(QS_MOSAIC_KEY)?.split(QS_SEPARATOR) ?? [];
   const renderOptionNames = qs.get(QS_RENDER_KEY)?.split(QS_SEPARATOR) ?? [];
-  const sortbyQs = qs.get(QS_SORT_KEY) ?? "desc";
+  const sortbyQs = qs.get(QS_SORT_KEY)?.split(QS_SEPARATOR) ?? [];
   const settings = qs.get(QS_SETTINGS_KEY)?.split(QS_SEPARATOR) ?? [];
   const editingIdx = qs.get(QS_ACTIVE_EDIT_KEY)
     ? parseInt(qs.get(QS_ACTIVE_EDIT_KEY) as string)
@@ -88,7 +88,7 @@ const loadQsV2 = (dispatch: ThunkDispatch<unknown, unknown, AnyAction>) => {
     collectionIds,
     mosaicNames,
     renderOptionNames,
-    sortbyQs as ISortDir,
+    sortbyQs as ISortDir[],
     settings,
     editingIdx,
     dispatch
@@ -110,7 +110,7 @@ const loadMosaicStateV2 = async (
   collectionIds: string[],
   mosaicNames: string[],
   renderOptionNames: string[],
-  defaultSort: ISortDir,
+  sortDirs: ISortDir[],
   settings: string[],
   editingIndex: number | undefined = undefined,
   dispatch: ThunkDispatch<unknown, unknown, AnyAction>
@@ -180,7 +180,7 @@ const loadMosaicStateV2 = async (
 
       const sortby = customQueryMetadata
         ? parseSortBy(customQueryMetadata.search.search.sortby)
-        : defaultSort;
+        : sortDirs[index] || "desc";
 
       // The registered cql will have had the collection id property added
       // which we don't need. It's stored directly on the state.
@@ -252,8 +252,8 @@ const getDefaultRenderName = (
   return renderName ? renderName : defaultName;
 };
 
-const parseSortBy = (sortby: ISortBy[]): ISortDir => {
+const parseSortBy = (sortby: ISortBy[] | undefined): ISortDir => {
   // Explorer only supports datetime sorts. If none is specified, use desc
-  const sort = sortby.find(s => s.field === "datetime");
+  const sort = sortby?.find(s => s.field === "datetime");
   return sort?.direction === "asc" ? "asc" : "desc";
 };

--- a/src/pages/Explore/state/inititalStateHelper.ts
+++ b/src/pages/Explore/state/inititalStateHelper.ts
@@ -11,10 +11,11 @@ import {
   QS_RENDER_KEY,
   QS_SEPARATOR,
   QS_SETTINGS_KEY,
+  QS_SORT_KEY,
   QS_V1_CUSTOM_KEY,
   QS_VERSION_KEY,
 } from "../components/Sidebar/selectors/hooks/useUrlStateV2";
-import { ILayerState, IMosaic, IMosaicInfo } from "../types";
+import { ILayerState, IMosaic, IMosaicInfo, ISortBy, ISortDir } from "../types";
 import { updateQueryStringParam } from "../utils";
 import { CqlExpressionParser } from "../utils/cql";
 import {
@@ -61,6 +62,7 @@ const loadQsV1 = (
       [collectionId],
       [mosaicName],
       [renderOptionName],
+      "desc",
       [],
       undefined,
       dispatch
@@ -76,6 +78,7 @@ const loadQsV2 = (dispatch: ThunkDispatch<unknown, unknown, AnyAction>) => {
   const collectionIds = qs.get(QS_COLLECTION_KEY)?.split(QS_SEPARATOR) ?? [];
   const mosaicNames = qs.get(QS_MOSAIC_KEY)?.split(QS_SEPARATOR) ?? [];
   const renderOptionNames = qs.get(QS_RENDER_KEY)?.split(QS_SEPARATOR) ?? [];
+  const sortbyQs = qs.get(QS_SORT_KEY) ?? "desc";
   const settings = qs.get(QS_SETTINGS_KEY)?.split(QS_SEPARATOR) ?? [];
   const editingIdx = qs.get(QS_ACTIVE_EDIT_KEY)
     ? parseInt(qs.get(QS_ACTIVE_EDIT_KEY) as string)
@@ -85,6 +88,7 @@ const loadQsV2 = (dispatch: ThunkDispatch<unknown, unknown, AnyAction>) => {
     collectionIds,
     mosaicNames,
     renderOptionNames,
+    sortbyQs as ISortDir,
     settings,
     editingIdx,
     dispatch
@@ -106,6 +110,7 @@ const loadMosaicStateV2 = async (
   collectionIds: string[],
   mosaicNames: string[],
   renderOptionNames: string[],
+  defaultSort: ISortDir,
   settings: string[],
   editingIndex: number | undefined = undefined,
   dispatch: ThunkDispatch<unknown, unknown, AnyAction>
@@ -165,9 +170,17 @@ const loadMosaicStateV2 = async (
         : await registerStacFilter(collection.id, mosaic, mosaic.cql, false);
 
       // Get the named mosaic's cql, or fetch the cql for a custom query's searchId
-      const cql = isCustomQuery
-        ? (await fetchSearchIdMetadata(searchId)).search.search.filter.args
+      const customQueryMetadata = isCustomQuery
+        ? await fetchSearchIdMetadata(searchId)
+        : null;
+
+      const cql = customQueryMetadata
+        ? customQueryMetadata.search.search.filter.args
         : mosaic.cql;
+
+      const sortby = customQueryMetadata
+        ? parseSortBy(customQueryMetadata.search.search.sortby)
+        : defaultSort;
 
       // The registered cql will have had the collection id property added
       // which we don't need. It's stored directly on the state.
@@ -175,7 +188,12 @@ const loadMosaicStateV2 = async (
         exp => new CqlExpressionParser(exp).property !== "collection"
       );
 
-      const query = { ...mosaic, searchId, cql: cqlClean };
+      const query: IMosaic = {
+        ...mosaic,
+        searchId,
+        cql: cqlClean,
+        sortby: sortby,
+      };
 
       // Fetch the minzoom from the tilejson endpoint for this collection/renderOption
       const minZoom = (await fetchTileJson(query, renderOption, collection)).minzoom;
@@ -232,4 +250,10 @@ const getDefaultRenderName = (
 ): string => {
   const defaultName = mosaicInfo.renderOptions?.[0].name || "";
   return renderName ? renderName : defaultName;
+};
+
+const parseSortBy = (sortby: ISortBy[]): ISortDir => {
+  // Explorer only supports datetime sorts. If none is specified, use desc
+  const sort = sortby.find(s => s.field === "datetime");
+  return sort?.direction === "asc" ? "asc" : "desc";
 };

--- a/src/pages/Explore/state/mosaicSlice.ts
+++ b/src/pages/Explore/state/mosaicSlice.ts
@@ -22,7 +22,7 @@ export const initialMosaicState: IMosaic = {
   name: null,
   description: null,
   cql: [],
-  sortby: null,
+  sortby: "desc",
   searchId: null,
 };
 

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -74,7 +74,7 @@ export interface ISearchIdMetadata {
     hash: string;
     search: {
       filter: { args: ICqlExpressionList };
-      sortby: ISortBy[];
+      sortby: ISortBy[] | undefined;
     };
   };
 }

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -26,7 +26,7 @@ export interface IMosaic {
   name: string | null;
   description: string | null;
   cql: ICqlExpressionList;
-  sortby: [] | null;
+  sortby: ISortDir | undefined;
   searchId?: string | null;
 }
 
@@ -60,14 +60,22 @@ export interface IQueryable {
   properties: { [key: string]: any };
 }
 
+export type ISortDir = "asc" | "desc";
+export interface ISortBy {
+  field: string;
+  direction: ISortDir;
+}
+
 export interface ISearchIdMetadata {
   links: IStacLink[];
   metadata: { type: string };
   orderby: string;
   search: {
     hash: string;
-    search: { filter: { args: ICqlExpressionList } };
-    orderby: string;
+    search: {
+      filter: { args: ICqlExpressionList };
+      sortby: ISortBy[];
+    };
   };
 }
 

--- a/src/pages/Explore/utils/hooks/useStacFilter.ts
+++ b/src/pages/Explore/utils/hooks/useStacFilter.ts
@@ -5,10 +5,16 @@ import { collectionFilter, geomFilter } from "../stac";
 import { IMosaic } from "pages/Explore/types";
 import { CQL_VALS_IDX, DEFAULT_QUERY_LIMIT } from "../constants";
 import {
+  initialMosaicState,
   selectCurrentCql,
   selectCurrentMosaic,
 } from "pages/Explore/state/mosaicSlice";
 import { CqlExpression, CqlInExpression, ICqlExpressionList } from "../cql/types";
+
+export const makeSortBy = (mosaic: IMosaic) => {
+  const sortby = mosaic.sortby;
+  return [{ field: "datetime", direction: sortby }];
+};
 
 export const makeFilterBody = (
   baseFilter: (IStacFilterCollection | IStacFilterGeom | null)[],
@@ -18,13 +24,15 @@ export const makeFilterBody = (
 ): IStacFilter => {
   const optimizedCql = optimizeCqlExpressions(cql);
 
+  const fullQuery = { ...initialMosaicState, ...query };
+
   // Combine base filters with any selected filters, removing any nulls
   const filterBody = [...baseFilter, ...optimizedCql].filter(Boolean);
 
   return {
     "filter-lang": "cql2-json",
     filter: { op: "and", args: filterBody },
-    sortby: query.sortby || undefined,
+    sortby: makeSortBy(fullQuery),
     limit: limit,
   } as IStacFilter;
 };

--- a/src/pages/Explore/utils/index.ts
+++ b/src/pages/Explore/utils/index.ts
@@ -4,6 +4,7 @@ import {
   QS_COLLECTION_KEY,
   QS_MOSAIC_KEY,
   QS_RENDER_KEY,
+  QS_SORT_KEY,
   QS_V1_CUSTOM_KEY,
   QS_VERSION_KEY,
 } from "../components/Sidebar/selectors/hooks/useUrlStateV2";
@@ -13,6 +14,7 @@ export const resetMosaicQueryStringState = () => {
     QS_COLLECTION_KEY,
     QS_MOSAIC_KEY,
     QS_RENDER_KEY,
+    QS_SORT_KEY,
     QS_ACTIVE_EDIT_KEY,
     QS_VERSION_KEY,
     QS_V1_CUSTOM_KEY,


### PR DESCRIPTION
Adds new menu options on search results to sort by datetime asc or desc. The value is saved in state and sent with search or registered query (so will affect the tile order). State is preserved through searchId or query string depending on if a preconfigured mosaic is being used.