### PR TITLE
Use cibuild script to build SWA

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
+++ b/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
@@ -25,10 +25,10 @@ jobs:
       REACT_APP_HUB_URL: ${{ secrets.HUB_URL }}
       REACT_APP_AUTH_URL: ${{ secrets.AUTH_URL }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: npm-cache
         with:
           path: ~/.npm

--- a/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
+++ b/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
@@ -51,6 +51,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           skip_deploy_on_missing_secrets: true
           action: "upload"
+          app_build_command: "./scripts/cibuild"
           app_location: "/"
           api_location: "api"
           output_location: "build"

--- a/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
+++ b/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
@@ -44,7 +44,7 @@ jobs:
           echo -e "User-agent: *\nDisallow: /\n" > public/robots.txt
       - name: Build optimized bundle
         id: build-bundle
-        run ./scripts/cibuild
+        run: ./scripts/cibuild
       - name: Deploy (Staging)
         id: builddeploy-staging
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
+++ b/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Inject disallow crawling for robots.txt
         run: |
           echo -e "User-agent: *\nDisallow: /\n" > public/robots.txt
-      - name: Build And Deploy (Staging)
+      - name: Build optimized bundle
+        id: build-bundle
+        run ./scripts/cibuild
+      - name: Deploy (Staging)
         id: builddeploy-staging
         uses: Azure/static-web-apps-deploy@v1
         with:
@@ -51,10 +54,10 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           skip_deploy_on_missing_secrets: true
           action: "upload"
-          app_build_command: "./scripts/cibuild"
-          app_location: "/"
+          skip_app_build: true
+          app_location: "build"
           api_location: "api"
-          output_location: "build"
+          output_location: ""
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
@@ -32,6 +32,9 @@ jobs:
         run: ./scripts/update
       - name: Test and lint
         run: ./scripts/test
+      - name: Build optimized bundle
+        id: build-bundle
+        run: ./scripts/cibuild
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -41,8 +44,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           skip_deploy_on_missing_secrets: true
           action: "upload"
-          app_build_command: "./scripts/cibuild"
-          app_location: "/"
+          skip_app_build: true
+          app_location: "build"
           api_location: "api"
           output_location: "build"
 

--- a/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
@@ -25,7 +25,7 @@ jobs:
       REACT_APP_AZMAPS_KEY: ${{ secrets.AZMAPS_KEY }}
       REACT_APP_HUB_URL: ${{ secrets.HUB_URL }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Build docs and metadata

--- a/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
@@ -41,6 +41,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           skip_deploy_on_missing_secrets: true
           action: "upload"
+          app_build_command: "./scripts/cibuild"
           app_location: "/"
           api_location: "api"
           output_location: "build"

--- a/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
@@ -25,10 +25,10 @@ jobs:
       REACT_APP_HUB_URL: ${{ secrets.HUB_URL }}
       REACT_APP_AUTH_URL: ${{ secrets.AUTH_URL }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: npm-cache
         with:
           path: ~/.npm

--- a/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
@@ -51,7 +51,6 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           skip_deploy_on_missing_secrets: true
           action: "upload"
-          app_build_command: "./scripts/cibuild"
           app_location: "/"
           api_location: "api"
           output_location: "build"

--- a/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Inject disallow crawling for robots.txt
         run: |
           echo -e "User-agent: *\nDisallow: /\n" > public/robots.txt
+      - name: Build optimized bundle
+        id: build-bundle
+        run: ./scripts/cibuild
       - name: Build And Deploy (Test)
         id: builddeploy-test
         uses: Azure/static-web-apps-deploy@v1
@@ -51,7 +54,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           skip_deploy_on_missing_secrets: true
           action: "upload"
-          app_location: "/"
+          skip_app_build: true
+          app_location: "build"
           api_location: "api"
           output_location: "build"
 

--- a/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
@@ -51,6 +51,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           skip_deploy_on_missing_secrets: true
           action: "upload"
+          app_build_command: "./scripts/cibuild"
           app_location: "/"
           api_location: "api"
           output_location: "build"

--- a/.github/workflows/cypress-ci.yml
+++ b/.github/workflows/cypress-ci.yml
@@ -15,7 +15,7 @@ jobs:
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
@@ -27,12 +27,12 @@ jobs:
           wait-on: http://localhost:3000
           wait-on-timeout: 95
           browser: chrome
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -17,6 +17,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             run --rm --no-deps app \
             npm run build
 
-        cp staticwebapp.config.json build/
+        docker-compose \
+            -f docker-compose.yml \
+            run --rm --no-deps app \
+            cp staticwebapp.config.json build/
     fi
 fi

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -16,5 +16,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             -f docker-compose.yml \
             run --rm --no-deps app \
             npm run build
+
+        cp staticwebapp.config.json build/
     fi
 fi


### PR DESCRIPTION
The SWA action builds the npm project directly in the workspace, but there can be conflicting file permissions when node_modules was built via the build container during the update script. Keeping both build steps in the same container should alleviate any contention.