### PR TITLE
Pass REACT_APP env vars to build container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,12 @@ services:
       - CHOKIDAR_INTERVAL=100
 
       # Environments where .env is present will mount and use it. CI will need
-      # environment variables required for tests to be set.
+      # environment variables set via GH Actions to test and build.
       - REACT_APP_API_ROOT
+      - REACT_APP_IMAGE_API_ROOT
+      - REACT_APP_AZMAPS_KEY
+      - REACT_APP_ONEDS_TENANT_KEY
+      - REACT_APP_HUB_URL
     volumes:
       - .:/usr/src
       - ~/.npm:/root/.npm


### PR DESCRIPTION
Previously, production builds were done directly on the worker using the SWA GH Action. Using the cibuild script, which does a custom build in a container, will need the env vars made available to it to include them in the bundle.