### PR TITLE
Enforce PNG format for item tiles

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -181,7 +181,7 @@ export const makeTileJsonUrl = (
 
   // Rendering a single Item
   if (item && collection) {
-    return `${DATA_URL}/item/tilejson.json?collection=${collection.id}&${scaleParam}&item=${item.id}${format}`;
+    return `${DATA_URL}/item/tilejson.json?collection=${collection.id}&${scaleParam}&item=${item.id}&${renderParams}${format}`;
   }
 
   // Rendering a STAC search mosaic

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -181,8 +181,7 @@ export const makeTileJsonUrl = (
 
   // Rendering a single Item
   if (item && collection) {
-    const forcePngRenderParams = renderParams.replace("jpg", "png");
-    return `${DATA_URL}/item/tilejson.json?collection=${collection.id}&${scaleParam}&item=${item.id}&${forcePngRenderParams}`;
+    return `${DATA_URL}/item/tilejson.json?collection=${collection.id}&${scaleParam}&item=${item.id}${format}`;
   }
 
   // Rendering a STAC search mosaic


### PR DESCRIPTION
PNG is specifically set for tiles when no format has been specified in the render options for a collection.