### PR TITLE
Add: Introduction for users new to Python geospatial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Changelog <overview/changelog>
 :maxdepth: 1
 :caption: Quickstarts
 
+Warming up: What will you need going forward with PC Hub? <quickstarts/introduction>
 Reading from the STAC API <quickstarts/reading-stac>
 quickstarts/reading-stac-r
 quickstarts/reading-zarr-data

--- a/etl/config/external_docs_config.yml
+++ b/etl/config/external_docs_config.yml
@@ -28,3 +28,4 @@
 - file_url: quickstarts/reading-tabular-data.ipynb
 - file_url: quickstarts/reading-zarr-data.ipynb
 - file_url: quickstarts/storage.ipynb
+- file_url: quickstarts/introduction.ipynb


### PR DESCRIPTION
[User Story: 3702 - Introduction for users new to Python geospatial](https://dev.azure.com/planetary-computer/Planetary%20Computer%20Components/_workitems/edit/3702)

Adds the new introduction documentation ([PR](https://github.com/microsoft/PlanetaryComputerExamples/pull/242) pending) as a new item in the **documentation quick start**.

**Working title:** Warming up: what will you need going forward with Planetary Computer Hub?

![pc-docs-introduction](https://user-images.githubusercontent.com/80648005/210630731-48385501-f631-4690-884b-811af028cc9c.jpg)
