### PR TITLE
Removed noaa-climate-normals storage dataset

### DIFF
--- a/src/config/storageDatasets.yml
+++ b/src/config/storageDatasets.yml
@@ -116,14 +116,6 @@ noaa-rap:
   thumbnailUrl: thunder_storm.jpg
   keywords: [North America, NOAA, Weather]
 
-noaa-climatenormals:
-  title: NOAA US Climate Normals
-  category: Climate/Weather
-  short_description: Typical climate conditions for the U.S. from 1981-present
-  infoUrl: https://aka.ms/ai4edata-climatenormals
-  thumbnailUrl: climate_normals.jpg
-  keywords: [North America, NOAA, Weather]
-
 ooi-camhd:
   title: Ocean Observatories Initiative CAMHD
   category: Biodiversity


### PR DESCRIPTION
These are ingested as STAC datsaets in staging. Removing the storage dataset to prevent duplication.

https://planetarycomputer-staging.microsoft.com/catalog?filter=climate+normal