### PR TITLE
Add additional GOES storage datasets

### DIFF
--- a/src/config/storageDatasets.yml
+++ b/src/config/storageDatasets.yml
@@ -1,4 +1,4 @@
-# Configuration for "other dataset" section, see type `NonApiDatasetEntry` for details.
+# Configuration for "other dataset" section, see type `StorageDatasetEntry` for details.
 # The value for the dataset key should match the file name of the dataset in the ai4e dataset repo.
 ghe:
   title: Global Hydro Estimator
@@ -7,6 +7,38 @@ ghe:
   infoUrl: http://aka.ms/ai4edata-ghe
   thumbnailUrl: RE4ucH7.jpg
   keywords: [NOAA, Global, Precipitation]
+
+goes-fdc:
+  title: GOES Fire Detection and Characterization (FDC)
+  category: Climate/Weather
+  short_description: Maps of fires, including radiative power, temperature, size, and classification
+  infoUrl: https://microsoft.github.io/AIforEarthDataSets/data/goes-fdc.html
+  thumbnailUrl: goes-fdc-thumbnail.png
+  keywords: [GOES, NOAA, Fire]
+
+goes-lst:
+  title: GOES Land Surface Temperature (LST)
+  category: Temperature
+  short_description: Land Surface Temperature (LST) estimation
+  infoUrl: https://microsoft.github.io/AIforEarthDataSets/data/goes-lst.html
+  thumbnailUrl: goes-lst-thumbnail.png
+  keywords: [GOES, NOAA, Temperature]
+
+goes-rrqpe:
+  title: GOES Rainfall Rate and Quantitative Precipitation Estimation (RRQPE)
+  category: Weather
+  short_description: Maps of expected rainfall rate and precipitation
+  infoUrl: https://microsoft.github.io/AIforEarthDataSets/data/goes-rrqpe.html
+  thumbnailUrl: goes-rrqpe-thumbnail.png
+  keywords: [GOES, NOAA, Rainfall, Precipitation]
+
+goes-sst:
+  title: GOES Sea Surface
+  category: Temperature
+  short_description: Sea Surface Temperature (SST) estimate.
+  infoUrl: https://microsoft.github.io/AIforEarthDataSets/data/goes-sst.html
+  thumbnailUrl: goes-sst-thumbnail.png
+  keywords: [GOES, NOAA, Ocean, Temperature]
 
 doe-wave:
   title: High Resolution Ocean Surface Wave Hindcast


### PR DESCRIPTION
This PR adds storage dataset entries for the additional 4 GOES products that the Planetary Computer hosts in its storage accounts but are not yet fully integrated with the API.