### PR TITLE
Don't crash on malformed collections without assets

### DIFF
--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -30,7 +30,7 @@ export const isValidExplorer = (collection: IStacCollection) => {
       a.type?.toLowerCase().includes("geotiff")
     );
     const isHidden = Boolean(collections[collection.id]?.hideInExplorer);
-    const hasCollectionTileJson = !!Object.values(collection.assets).find(a =>
+    const hasCollectionTileJson = !!Object.values(collection.assets || {}).find(a =>
       a.roles?.includes("tiles")
     );
 


### PR DESCRIPTION
Collections in test/development may not yet have their assets defined.