### PR TITLE
Include collection id as filter attribute

### DIFF
--- a/src/pages/Catalog2/Catalog.FilteredCollectionList.tsx
+++ b/src/pages/Catalog2/Catalog.FilteredCollectionList.tsx
@@ -91,6 +91,7 @@ export const CatalogFilteredCollectionList: React.FC<
   const searchIndex = useMemo(() => {
     const searchIndex = new MiniSearch({
       fields: [
+        "id",
         "title",
         "msft:short_description",
         "keywords",


### PR DESCRIPTION
Id was scored but not included in catalog frontend filter 