### PR TITLE
Handle newly generated pgstac.queryable content 

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,25 +1,7 @@
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8
+FROM mcr.microsoft.com/azure-functions/python:4-python3.9
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
-
-# Install azure functions core tools
-ENV DEBIAN_VERSION=10
-
-RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
-RUN mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
-RUN wget -q https://packages.microsoft.com/config/debian/$DEBIAN_VERSION/prod.list
-RUN mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
-RUN chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
-RUN chown root:root /etc/apt/sources.list.d/microsoft-prod.list
-
-# Fix for https://github.com/Azure/azure-functions-docker/issues/874
-RUN sed -i '/jessie/d' /etc/apt/sources.list
-
-RUN apt-get update
-
-# Must use functions v3 to keep support for function proxies
-RUN apt-get install azure-functions-core-tools-3
 
 COPY requirements.txt /
 RUN pip install -r /requirements.txt

--- a/src/pages/Explore/components/Sidebar/selectors/CustomQueryBuilder.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/CustomQueryBuilder.tsx
@@ -55,7 +55,7 @@ const CustomQueryBuilder = () => {
       <Separator styles={separatorStyles} />
       <Stack horizontal tokens={customStackTokens} styles={customStackStyles}>
         <Text styles={textStyle}>Custom filters</Text>
-        <AddFilter queryable={queryable} cql={parsedCql} />
+        <AddFilter queryables={queryable} cql={parsedCql} />
       </Stack>
       {isLoading && loadingIndicator}
       {dateControl}

--- a/src/pages/Explore/components/query/AddFilter/AddFilter.tsx
+++ b/src/pages/Explore/components/query/AddFilter/AddFilter.tsx
@@ -16,16 +16,22 @@ import {
 import { CqlParser } from "pages/Explore/utils/cql";
 import { makeDefaultCqlExpression } from "pages/Explore/utils/cql/helpers";
 import { renderPlaceholder } from "pages/Explore/utils/dropdownRenderers";
+import {
+  getCurrentProperties,
+  getFilteredQueryables,
+  makeDropdownItems,
+} from "./helpers";
 
 interface AddAttributeProps {
-  queryable: JSONSchema | undefined;
+  queryables: JSONSchema | undefined;
   cql: CqlParser | null;
 }
 
-export const AddFilter = ({ queryable, cql }: AddAttributeProps) => {
+export const AddFilter = ({ queryables, cql }: AddAttributeProps) => {
   const dispatch = useExploreDispatch();
   const existingProperties = getCurrentProperties(cql);
-  const options = makeDropdownItems(queryable, existingProperties);
+  const filteredQueryables = getFilteredQueryables(queryables);
+  const options = makeDropdownItems(filteredQueryables, existingProperties);
 
   const handleChange = (_: any, item: IDropdownOption | undefined) => {
     const property = item?.key as string;
@@ -57,35 +63,6 @@ export const AddFilter = ({ queryable, cql }: AddAttributeProps) => {
       onChange={handleChange}
     />
   );
-};
-
-const getCurrentProperties = (cql: CqlParser | null) => {
-  const existing = cql?.expressions.map(exp => exp.property);
-  return existing || [];
-};
-
-const makeDropdownItems = (
-  queryable: JSONSchema | undefined,
-  existingProperties: string[]
-): IDropdownOption[] => {
-  const keys = Object.keys(queryable?.properties || {});
-  const fields = queryable?.properties;
-
-  return keys.map(key => {
-    const field = fields?.[key] as JSONSchema;
-    const exists = existingProperties.includes(key);
-    const isAcquired = key === "datetime";
-    const tooltip = isAcquired ? "This filter cannot be removed" : field.description;
-
-    return {
-      key,
-      text: field.title || "",
-      title: tooltip,
-      data: field,
-      checked: exists,
-      disabled: isAcquired,
-    };
-  });
 };
 
 const theme = getTheme();

--- a/src/pages/Explore/components/query/AddFilter/helpers.ts
+++ b/src/pages/Explore/components/query/AddFilter/helpers.ts
@@ -1,0 +1,69 @@
+import { JSONSchema } from "@apidevtools/json-schema-ref-parser";
+import { IDropdownOption } from "@fluentui/react";
+import { CqlParser } from "pages/Explore/utils/cql";
+import { getQueryableTitle } from "pages/Explore/utils/stac";
+
+const OMITTED_PREFIXES = [
+  "geometry",
+  "proj:",
+  "epsg:",
+  "label:",
+  "classification:",
+  "start_datetime",
+  "end_datetime",
+  "created",
+  "updated",
+];
+const OMITTED_TYPES = ["array"];
+
+export const getFilteredQueryables = (queryables: JSONSchema | undefined) => {
+  if (!queryables) return;
+
+  const filteredSchema = Object.assign(
+    Object.create(Object.getPrototypeOf(queryables)),
+    queryables
+  );
+
+  Object.keys(filteredSchema.properties).forEach(key => {
+    const isOmittedPrefix = OMITTED_PREFIXES.some(prefix => key.startsWith(prefix));
+    const isOmittedType = OMITTED_TYPES.includes(
+      filteredSchema.properties[key].type
+    );
+
+    if (isOmittedPrefix || isOmittedType) {
+      delete filteredSchema.properties[key];
+    }
+  });
+
+  return filteredSchema;
+};
+
+export const getCurrentProperties = (cql: CqlParser | null) => {
+  const existing = cql?.expressions.map(exp => exp.property);
+  return existing || [];
+};
+
+export const makeDropdownItems = (
+  queryable: JSONSchema | undefined,
+  existingProperties: string[]
+): IDropdownOption[] => {
+  const keys = Object.keys(queryable?.properties || {}).sort();
+  const fields = queryable?.properties;
+
+  return keys.map(key => {
+    const field = fields?.[key] as JSONSchema;
+    const exists = existingProperties.includes(key);
+    const text = getQueryableTitle(field, key);
+    const isAcquired = key === "datetime";
+    const title = isAcquired ? "This filter cannot be removed" : field.description;
+
+    return {
+      key,
+      text,
+      title,
+      data: field,
+      checked: exists,
+      disabled: isAcquired,
+    };
+  });
+};

--- a/src/pages/Explore/components/query/TextFieldBase/TextFieldBase.tsx
+++ b/src/pages/Explore/components/query/TextFieldBase/TextFieldBase.tsx
@@ -20,6 +20,7 @@ import { useExploreDispatch } from "pages/Explore/state/hooks";
 import { setCustomCqlExpressions } from "pages/Explore/state/mosaicSlice";
 import DropdownLabel from "../components/DropdownLabel";
 import { CqlOperator } from "pages/Explore/utils/cql/types";
+import { getQueryableTitle } from "pages/Explore/utils/stac";
 
 interface TextFieldProps<T extends string | number> {
   field: CqlExpressionParser<T>;
@@ -48,7 +49,7 @@ export const TextFieldBase = ({
   const dispatch = useExploreDispatch();
 
   const { fieldSchema } = field;
-  const labelPrefix = fieldSchema?.title || field.property;
+  const labelPrefix = getQueryableTitle(fieldSchema, field.property);
   const formattedValue = onFormatValue(field.value);
   const keyPrefix = `textstringcontrol-${field.property}`;
 

--- a/src/pages/Explore/utils/stac.ts
+++ b/src/pages/Explore/utils/stac.ts
@@ -5,6 +5,8 @@ import { BBox } from "geojson";
 import { IStacCollection, IStacFilterCollection, IStacFilterGeom } from "types/stac";
 import { CqlDateRange } from "./cql/types";
 import { formatDatetime, getDayEnd } from "./time";
+import { JSONSchema } from "@apidevtools/json-schema-ref-parser";
+import { titleCase } from "utils";
 
 export const collectionFilter = (
   collectionId: string | undefined
@@ -42,4 +44,10 @@ export const rangeFromTemporalExtent = (
   const end = interval[0][1] || formatDatetime(getDayEnd(new Date()));
 
   return [start, end];
+};
+
+export const getQueryableTitle = (field: JSONSchema | undefined, key: string) => {
+  // Get the value after a possible colon
+  const unprefixed = key.split(":").pop() || key;
+  return (field && field.title) || titleCase(unprefixed, "_");
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,8 +20,8 @@ export const capitalize = (value: string) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
-export const titleCase = (str: string) => {
-  return str.split(" ").map(capitalize).join(" ");
+export const titleCase = (str: string, splitChar: string = " ") => {
+  return str.split(splitChar).map(capitalize).join(" ");
 };
 
 export const isort = (a: string, b: string) =>


### PR DESCRIPTION
Queryables are now generated from source item data and encoded in pgstac directly, instead of the externally maintained configuration. As a result, there are new types that are unsupported by the query-builder or undesirable to include (like `proj:`)

Also upgrades the dev container for Azure Functions to v4.