### PR TITLE
Validate bbox before export

### DIFF
--- a/src/pages/Explore/components/Map/hooks/useMapDrawTools.ts
+++ b/src/pages/Explore/components/Map/hooks/useMapDrawTools.ts
@@ -47,12 +47,12 @@ export const useMapDrawTools = (
     const geometry = shape.toJson().geometry;
     // getBounds does not reliable generate a valid bounding box
     // for drawn polygons, so ensure the order is xmin, ymin, xmax, ymax
-    const bounds = shape.getBounds();
+    const [x1, y1, x2, y2] = shape.getBounds();
     const bbox = [
-      Math.min(bounds[0], bounds[2]),
-      Math.min(bounds[1], bounds[3]),
-      Math.max(bounds[0], bounds[2]),
-      Math.max(bounds[1], bounds[3]),
+      Math.min(x1, x2),
+      Math.min(y1, y2),
+      Math.max(x1, x2),
+      Math.max(y1, y2),
     ];
 
     const drawnShape: IDrawnShape = {

--- a/src/pages/Explore/components/Map/hooks/useMapDrawTools.ts
+++ b/src/pages/Explore/components/Map/hooks/useMapDrawTools.ts
@@ -44,10 +44,22 @@ export const useMapDrawTools = (
   }
 
   const handleShapeAdded = (shape: atlas.Shape): void => {
+    const geometry = shape.toJson().geometry;
+    // getBounds does not reliable generate a valid bounding box
+    // for drawn polygons, so ensure the order is xmin, ymin, xmax, ymax
+    const bounds = shape.getBounds();
+    const bbox = [
+      Math.min(bounds[0], bounds[2]),
+      Math.min(bounds[1], bounds[3]),
+      Math.max(bounds[0], bounds[2]),
+      Math.max(bounds[1], bounds[3]),
+    ];
+
     const drawnShape: IDrawnShape = {
-      geometry: shape.toJson().geometry,
-      bbox: shape.getBounds(),
+      geometry,
+      bbox,
     };
+
     dispatch(setDrawnShape(drawnShape));
     dispatch(setBboxDrawMode(false));
 


### PR DESCRIPTION
The Azure Maps bounding box would occasionally invert the xmin and xmax values of the bounding box under hard to determine circumstances. This nearly always happened for geometries that spanned large areas in both dimensions, but didn't seem to be related to anything incorrect from the source geometry. As a fail safe, the bbox is coerced into a xmin,ymin,xmax,ymax order assuming that x and y coordinates remain in their appropriate slots, but not always the right order.