### PR TITLE
Hide cil-gdpcir-cc-by-sa collection

### DIFF
--- a/src/config/datasets.yml
+++ b/src/config/datasets.yml
@@ -212,19 +212,9 @@ cil-gdpcir-cc-by:
       launch: datasets/cil-gdpcir/indicators.ipynb
 
 cil-gdpcir-cc-by-sa:
-  category: Climate/Weather
-  headerImg: ./images/cil-gdpcir.png
-  tabs:
-    - title: Example Notebook
-      src: cil-gdpcir-example.html
-      launch: datasets/cil-gdpcir/cil-gdpcir-example.ipynb
-    - title: Ensemble example
-      src: ensemble.html
-      launch: datasets/cil-gdpcir/ensemble.ipynb
-    - title: Climate indicators
-      src: indicators.html
-      launch: datasets/cil-gdpcir/indicators.ipynb
-
+  # Merged into cil-gdpcir-cc-by
+  isHidden: true
+ 
 cop-dem-glo-30:
   category: DEMs
   headerImg: ./images/cop-dem-glo-30-hero.png


### PR DESCRIPTION
The cc-by-sa 4.0 data was relicensed under cc-by 4.0. The cil-gdpcir-cc-by-sa collection is now redundant with cil-gdpcir-cc-by

xref https://github.com/microsoft/planetary-computer-tasks/commit/fb32d144d4ed64d2dda84c53084cb54cf8bb9ab4