### PR TITLE
Correct gdpcir is now made up of 2 collections

### DIFF
--- a/src/config/datasetGroups.yml
+++ b/src/config/datasetGroups.yml
@@ -346,7 +346,7 @@ cil-gdpcir:
 
 
     GDPCIR data can be accessed on the Microsoft Planetary Computer. The dataset is
-    made of of three collections, distinguished by data license. More information
+    made up of two collections, distinguished by data license. More information
     about the dataset is available in these collections, including access
     instructions and examples, data formats, available models, methods, and
     citation/licensing requirements, on each dataset's homepage linked below.


### PR DESCRIPTION
Tiny edit - GDPCIR group no longer has three collections, as the CC-BY-SA license has been changed to a CC-BY licenses and these groups were merged.

See also:
* https://github.com/microsoft/PlanetaryComputerDataCatalog/pull/438
* https://github.com/microsoft/planetary-computer-tasks/pull/213

Related PRs on ClimateImpactLab repo:
* https://github.com/ClimateImpactLab/downscaleCMIP6/pull/637
* https://github.com/ClimateImpactLab/downscaleCMIP6/issues/660

@TomAugspurger 