### PR TITLE
California Privacy Requirement website compliance

### DIFF
--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -11,4 +11,4 @@ nbformat==5.1.3
 numpydoc==1.1.0
 pyyaml==5.4.1
 requests
-sphinx==3.5.4
+sphinx==5.*

--- a/public/index.html
+++ b/public/index.html
@@ -114,10 +114,8 @@
       };
 
       //Initialize SDK
-      if ("%NODE_ENV%" === "development") { // TODO CHANGE BACK
+      if ("%NODE_ENV%" !== "development") { 
         analytics.initialize(config, []);
-
-
       }
     </script>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
     <div id="cookie-banner"></div>
     <div id="root"></div>
 
-    <script src="https://js.monitor.azure.com/scripts/c/ms.analytics-web-3.min.js"></script>
+    <script src="https://js.monitor.azure.com/scripts/c/ms.analytics-web-4.min.js"></script>
     <script src="https://consentdeliveryfd.azurefd.net/mscc/lib/v2/wcp-consent.js"></script>
     <script type="text/javascript">
       /*
@@ -49,6 +49,22 @@
         Cookie descriptions: https://osgwiki.com/wiki/JSLLv4#Cookies_Set.2FRead_by_JSLL
       */
 
+      function checkThirdPartyAdsOptOutCookie() {
+        try {
+          const ThirdPartyAdsOptOutCookieName = '3PAdsOptOut';
+          var cookieValue = getCookie(ThirdPartyAdsOptOutCookieName);
+
+          //for unauthenticated users
+          return cookieValue != 1;
+        } catch {
+          return true;
+        }
+      }
+
+      function getCookie(cookieName) {
+        var cookieValue = document.cookie.match('(^|;)\\s*' + cookieName + '\\s*=\\s*([^;]+)');
+        return (cookieValue) ? cookieValue[2] : '';
+      }
       // WCP initialization
       WcpConsent.init("en-US", "cookie-banner", function (err, siteConsent) {
         if (err != undefined) {
@@ -60,11 +76,18 @@
         }
       });
 
+      // Presence of the GPC indicates and opt-out of data sharing, mark the 1DS Analytics as such
+      var globalPrivacyControlEnabled = navigator.globalPrivacyControl;
+      // Set data sharing opt-in to false when GPC or AMC controls detected
+      var GPC_DataSharingOptIn = (globalPrivacyControlEnabled) ? false : checkThirdPartyAdsOptOutCookie();
+
       // 1DS initialization
       const analytics = new oneDS.ApplicationInsights();
       var config = {
         instrumentationKey: "%REACT_APP_ONEDS_TENANT_KEY%",
         propertyConfiguration: {
+          // From https://msasg.visualstudio.com/Shared%20Data/_git/1DS.JavaScript?path=%2Fextensions%2Fproperties%2FEUCC.md&_a=preview&anchor=npm-setup-analytics-web
+          gpcDataSharingOptIn: GPC_DataSharingOptIn,
           callback: {
             userConsentDetails: window.siteConsent
               ? window.siteConsent.getConsent
@@ -91,8 +114,10 @@
       };
 
       //Initialize SDK
-      if ("%NODE_ENV%" !== "development") {
+      if ("%NODE_ENV%" === "development") { // TODO CHANGE BACK
         analytics.initialize(config, []);
+
+
       }
     </script>
   </body>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -123,6 +123,16 @@ const Footer = ({ onGrid = true }) => {
                 {manageConsent}
               </li>
             )}
+            <li>
+                <a href="https://aka.ms/yourcaliforniaprivacychoices" style={{position: "relative", top: 4}}>
+                <div style={{display: "flex", alignItems: "center"}}>
+                  <img 
+                    src="data:image/svg+xml,%3Csvg%20role%3D%22img%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2030%2014%22%20height%3D%2216%22%20width%3D%2243%22%3E%3Ctitle%3ECalifornia%20Consumer%20Privacy%20Act%20(CCPA)%20Opt-Out%20Icon%3C%2Ftitle%3E%3Cpath%20d%3D%22M7.4%2012.8h6.8l3.1-11.6H7.4C4.2%201.2%201.6%203.8%201.6%207s2.6%205.8%205.8%205.8z%22%20style%3D%22fill-rule%3Aevenodd%3Bclip-rule%3Aevenodd%3Bfill%3A%23fff%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M22.6%200H7.4c-3.9%200-7%203.1-7%207s3.1%207%207%207h15.2c3.9%200%207-3.1%207-7s-3.2-7-7-7zm-21%207c0-3.2%202.6-5.8%205.8-5.8h9.9l-3.1%2011.6H7.4c-3.2%200-5.8-2.6-5.8-5.8z%22%20style%3D%22fill-rule%3Aevenodd%3Bclip-rule%3Aevenodd%3Bfill%3A%2306f%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M24.6%204c.2.2.2.6%200%20.8L22.5%207l2.2%202.2c.2.2.2.6%200%20.8-.2.2-.6.2-.8%200l-2.2-2.2-2.2%202.2c-.2.2-.6.2-.8%200-.2-.2-.2-.6%200-.8L20.8%207l-2.2-2.2c-.2-.2-.2-.6%200-.8.2-.2.6-.2.8%200l2.2%202.2L23.8%204c.2-.2.6-.2.8%200z%22%20style%3D%22fill%3A%23fff%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M12.7%204.1c.2.2.3.6.1.8L8.6%209.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4%207.7c-.2-.2-.2-.6%200-.8.2-.2.6-.2.8%200L8%208.6l3.8-4.5c.2-.2.6-.2.9%200z%22%20style%3D%22fill%3A%2306f%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E" 
+                    alt="privacy icon"/>
+                  <span>Your Privacy Choices</span>
+                  </div>
+                </a>
+            </li>
             <li className="x-hidden-focus">
               {" "}
               © Microsoft {new Date().getFullYear()}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -124,14 +124,18 @@ const Footer = ({ onGrid = true }) => {
               </li>
             )}
             <li>
-                <a href="https://aka.ms/yourcaliforniaprivacychoices" style={{position: "relative", top: 4}}>
-                <div style={{display: "flex", alignItems: "center"}}>
-                  <img 
-                    src="data:image/svg+xml,%3Csvg%20role%3D%22img%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2030%2014%22%20height%3D%2216%22%20width%3D%2243%22%3E%3Ctitle%3ECalifornia%20Consumer%20Privacy%20Act%20(CCPA)%20Opt-Out%20Icon%3C%2Ftitle%3E%3Cpath%20d%3D%22M7.4%2012.8h6.8l3.1-11.6H7.4C4.2%201.2%201.6%203.8%201.6%207s2.6%205.8%205.8%205.8z%22%20style%3D%22fill-rule%3Aevenodd%3Bclip-rule%3Aevenodd%3Bfill%3A%23fff%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M22.6%200H7.4c-3.9%200-7%203.1-7%207s3.1%207%207%207h15.2c3.9%200%207-3.1%207-7s-3.2-7-7-7zm-21%207c0-3.2%202.6-5.8%205.8-5.8h9.9l-3.1%2011.6H7.4c-3.2%200-5.8-2.6-5.8-5.8z%22%20style%3D%22fill-rule%3Aevenodd%3Bclip-rule%3Aevenodd%3Bfill%3A%2306f%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M24.6%204c.2.2.2.6%200%20.8L22.5%207l2.2%202.2c.2.2.2.6%200%20.8-.2.2-.6.2-.8%200l-2.2-2.2-2.2%202.2c-.2.2-.6.2-.8%200-.2-.2-.2-.6%200-.8L20.8%207l-2.2-2.2c-.2-.2-.2-.6%200-.8.2-.2.6-.2.8%200l2.2%202.2L23.8%204c.2-.2.6-.2.8%200z%22%20style%3D%22fill%3A%23fff%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M12.7%204.1c.2.2.3.6.1.8L8.6%209.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4%207.7c-.2-.2-.2-.6%200-.8.2-.2.6-.2.8%200L8%208.6l3.8-4.5c.2-.2.6-.2.9%200z%22%20style%3D%22fill%3A%2306f%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E" 
-                    alt="privacy icon"/>
+              <a
+                href="https://aka.ms/yourcaliforniaprivacychoices"
+                style={{ position: "relative", top: 4 }}
+              >
+                <div style={{ display: "flex", alignItems: "center" }}>
+                  <img
+                    src="data:image/svg+xml,%3Csvg%20role%3D%22img%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2030%2014%22%20height%3D%2216%22%20width%3D%2243%22%3E%3Ctitle%3ECalifornia%20Consumer%20Privacy%20Act%20(CCPA)%20Opt-Out%20Icon%3C%2Ftitle%3E%3Cpath%20d%3D%22M7.4%2012.8h6.8l3.1-11.6H7.4C4.2%201.2%201.6%203.8%201.6%207s2.6%205.8%205.8%205.8z%22%20style%3D%22fill-rule%3Aevenodd%3Bclip-rule%3Aevenodd%3Bfill%3A%23fff%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M22.6%200H7.4c-3.9%200-7%203.1-7%207s3.1%207%207%207h15.2c3.9%200%207-3.1%207-7s-3.2-7-7-7zm-21%207c0-3.2%202.6-5.8%205.8-5.8h9.9l-3.1%2011.6H7.4c-3.2%200-5.8-2.6-5.8-5.8z%22%20style%3D%22fill-rule%3Aevenodd%3Bclip-rule%3Aevenodd%3Bfill%3A%2306f%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M24.6%204c.2.2.2.6%200%20.8L22.5%207l2.2%202.2c.2.2.2.6%200%20.8-.2.2-.6.2-.8%200l-2.2-2.2-2.2%202.2c-.2.2-.6.2-.8%200-.2-.2-.2-.6%200-.8L20.8%207l-2.2-2.2c-.2-.2-.2-.6%200-.8.2-.2.6-.2.8%200l2.2%202.2L23.8%204c.2-.2.6-.2.8%200z%22%20style%3D%22fill%3A%23fff%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M12.7%204.1c.2.2.3.6.1.8L8.6%209.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4%207.7c-.2-.2-.2-.6%200-.8.2-.2.6-.2.8%200L8%208.6l3.8-4.5c.2-.2.6-.2.9%200z%22%20style%3D%22fill%3A%2306f%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E"
+                    alt="privacy icon"
+                  />
                   <span>Your Privacy Choices</span>
-                  </div>
-                </a>
+                </div>
+              </a>
             </li>
             <li className="x-hidden-focus">
               {" "}


### PR DESCRIPTION
Add a compliance check for ensuring that global privacy opt-out is
respected in the user browser settings or cookies. Planetary Computer
does not use any advertising cookies, but does collect usage information
that is aggregated into 1DS. This means that it is in scope for
compliance with the CPR.

Check if the browser emits a Global Do not Track signal, or that an AMC
(account.ms.com) privacy dashboard cookie is set.

Also adds a new footer link allowing users to directly set their ad privacy 
choices on AMC.


Manual test cases as indicated in requirement docs:

1. [x] GPC not enabled
2. [x] GPC signal detected and true
3. [x] GPC signal detected and false
4. [x] AMC cookie does not exist
5. [x] AMC cookie value is 1
6. [x] AMC cookie value other than 1