### PR TITLE
Adding note about REACT_APP_API_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ First, copy `.env.sample` file to `.env`, and ensure the configuration values ar
 
 | Name | Value | Description |
 |------|-------|-------------|
-|`REACT_APP_API_ROOT`| <https://planetarycomputer-staging.microsoft.com> | The root URL for the STAC API, either prod, staging or a local instance.
+|`REACT_APP_API_ROOT`| <https://planetarycomputer-staging.microsoft.com> | The root URL for the STAC API, either prod, staging or a local instance. If the URL ends in 'stac', this is a special case that is handled by replacing 'stac' with the target service, e.g. 'data' or 'sas'
 |`REACT_APP_TILER_ROOT`| Optional | The root URL for the data tiler API, if not hosted from the domain of the STAC API.
 |`REACT_APP_IMAGE_API_ROOT`| PC APIs pcfunc endpoint | The root URL for the image data API for animations.
 |`REACT_APP_AZMAPS_KEY`| Retrieve from Azure Portal | The key used to authenticate the Azure Maps inset map on a dataset detail page.


### PR DESCRIPTION
This adds a note about how the REACT_APP_API_ROOT is handled differently if the value ends in `stac`.

Really, this change is just to kick off the deployment of the test environment through GitHub Actions.