### PR TITLE
"Skip To Main" and other accessibility fixes

### DIFF
--- a/src/components/DefaultBanner.js
+++ b/src/components/DefaultBanner.js
@@ -5,7 +5,11 @@ const DefaultBanner = ({ children }) => {
     <div className="banner-item">{child}</div>
   ));
 
-  const banner = <div className="header-banner grid-content" id="generated-docs-content">{wrapped}</div>;
+  const banner = (
+    <div className="header-banner grid-content" id="generated-docs-content">
+      {wrapped}
+    </div>
+  );
 
   return banner;
 };

--- a/src/components/DefaultBanner.js
+++ b/src/components/DefaultBanner.js
@@ -5,7 +5,7 @@ const DefaultBanner = ({ children }) => {
     <div className="banner-item">{child}</div>
   ));
 
-  const banner = <div className="header-banner grid-content">{wrapped}</div>;
+  const banner = <div className="header-banner grid-content" id="generated-docs-content">{wrapped}</div>;
 
   return banner;
 };

--- a/src/components/Header/Header.Bar.tsx
+++ b/src/components/Header/Header.Bar.tsx
@@ -6,7 +6,9 @@ import {
   logoLinkStyle,
   productNameStyle,
 } from "./styles";
-import { Stack, Text } from "@fluentui/react";
+import { Link, Stack, Text } from "@fluentui/react";
+import { skipContentStyle } from "components/Header/styles";
+
 
 export const HeaderBar: React.FC = () => {
   return (
@@ -17,6 +19,15 @@ export const HeaderBar: React.FC = () => {
       verticalAlign="center"
       tokens={headerTokens}
     >
+      <Link
+        className={skipContentStyle}
+        onClick={() => {
+          const urlWithoutHash = window.location.href.split("#")[0];
+          window.location.href = urlWithoutHash + "#generated-docs-content";
+        }}
+      >
+        Skip to content
+      </Link>
       <a
         className={logoLinkStyle}
         href="https://www.microsoft.com"

--- a/src/components/Header/Header.Bar.tsx
+++ b/src/components/Header/Header.Bar.tsx
@@ -9,7 +9,6 @@ import {
 import { Link, Stack, Text } from "@fluentui/react";
 import { skipContentStyle } from "components/Header/styles";
 
-
 export const HeaderBar: React.FC = () => {
   return (
     <Stack

--- a/src/pages/Docs/Docs.index.tsx
+++ b/src/pages/Docs/Docs.index.tsx
@@ -9,7 +9,6 @@ import DocsHtmlContent from "./components/DocsHtmlContent";
 import Topic from "./components/Topic";
 import { DATA_URL, SAS_URL, STAC_URL } from "../../utils/constants";
 import ScrollToTop from "../../components/ScrollToTop";
-import { skipContentStyle } from "components/Header/styles";
 
 const OpenApiSpec = React.lazy(() => import("./components/OpenApiSpec"));
 
@@ -60,15 +59,6 @@ const Docs = () => {
 
   const documentationPane = (
     <div className="grid-content" style={docPageStyle}>
-      <Link
-        className={skipContentStyle}
-        onClick={() => {
-          const urlWithoutHash = window.location.href.split("#")[0];
-          window.location.href = urlWithoutHash + "#generated-docs-content";
-        }}
-      >
-        Skip to content
-      </Link>
       {tocComponent}
       <div style={docContentStyle}>
         {breadcrumb}

--- a/src/pages/Explore/components/Map/components/LegendControl/LayerOptions.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/LayerOptions.tsx
@@ -39,6 +39,7 @@ export const OpacityCmdButton: React.FC<LayerOptionsProps> = ({
         title="Adjust layer opacity"
         aria-label={`Set ${layer.collection?.title} ${layer.renderOption?.name} opacity`}
         iconProps={{ iconName: "CircleHalfFull" }}
+        role="menuitem"
         styles={
           layer.layer.opacity === 100 ? cmdButtonStyles : activeCmdButtonStyles
         }

--- a/src/pages/Explore/components/Map/components/LegendControl/LegendCmdBar.tsx
+++ b/src/pages/Explore/components/Map/components/LegendControl/LegendCmdBar.tsx
@@ -59,6 +59,7 @@ const LegendCmdBar = ({
       {btnVisible}
       {btnOpacity}
       <IconButton
+        role="menuitem"
         aria-label={expand.title}
         title={expand.title}
         disabled={isExpandDisabled}

--- a/src/pages/Explore/components/Sidebar/selectors/CatalogSelector/CatalogSelector.index.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/CatalogSelector/CatalogSelector.index.tsx
@@ -128,7 +128,7 @@ export const CatalogSelector = () => {
   return (
     <>
       <DefaultButton
-        ariaLabel="Select a dataset to visualize"
+        ariaLabel={buttonText}
         title="Select a dataset to visualize"
         text={buttonText}
         onRenderText={renderText("GlobeLocation", buttonText)}


### PR DESCRIPTION
Fix in explorer page for - [Screen Reader-Planetary Computer WCP Site-Explore Dataset]: Screen Reader is not announcing the current selected value of the button.

Fix in explorer for -[Programmatic Access-Planetary Computer WCP Site- Explore Dataset]: Ensures elements with an ARIA role that require child roles contain them.

The fix also moves the "Skip to Main" hidden button to the top of the page for better accessibility. 