### PR TITLE
Docs: add obstore tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Explorer <overview/explorer>
 Use VS Code <overview/ui-vscode>
 Use GitHub Codespaces <overview/ui-codespaces>
 Using QGIS <overview/qgis-plugin>
+Reading data with obstore <overview/obstore>
 Changelog <overview/changelog>
 ```
 

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -1,18 +1,18 @@
 # Reading Planetary Computer data with obstore
 
-[obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. While much of the Planetary Computer ecosystem supports `planetary_computer.sign()` and fsspec, obstore offers a more modern path: SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
+[obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. Using obstore, SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
 
-A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub][nb-hub] · [View on GitHub][nb-github]
+A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/microsoft/PlanetaryComputerExamples&urlpath=lab/tree/PlanetaryComputerExamples/quickstarts/obstore.ipynb&branch=main) · [View on GitHub](https://github.com/microsoft/PlanetaryComputerExamples/blob/main/quickstarts/obstore.ipynb)
 
 ## Install obstore
 
-obstore works in any Python project — a script, a Jupyter notebook, a FastAPI backend, a Dagster or Airflow pipeline. To get started, install obstore alongside `pystac-client` (for searching the Planetary Computer's STAC API) and the HTTP libraries that power its credential providers:
+obstore works in any Python project. To get started, install obstore alongside `pystac-client` (for searching the Planetary Computer's STAC API) and the HTTP libraries that power its credential providers:
 
 ```bash
 uv add obstore pystac-client requests aiohttp aiohttp_retry
 ```
 
-`requests` powers the sync credential provider; `aiohttp` and `aiohttp_retry` power the async one. Install both unless you know you only need one path. If you already have a project, you can substitute `pip install`, `poetry add`, or whatever your project uses.
+`requests` powers the sync credential provider; `aiohttp` and `aiohttp_retry` power the async one. Install both unless you know you only need one path.
 
 ## Connect to a Planetary Computer asset
 
@@ -45,15 +45,11 @@ The most common starting point is a STAC asset returned from a search. obstore's
    store = AzureStore(credential_provider=provider)
    ```
 
-That's the full setup. Every read, write, or library handoff below reuses the same `store`.
-
 ## Read bytes from the store
 
 Once you have a working store, obstore exposes three read operations that map directly to native Azure Blob API calls.
 
-A note before you read: `from_asset()` scopes the store to that *specific blob* — the asset URL becomes the store's prefix. Reads use `""` as the path. Passing the asset href on top of the prefix would double it up and fail with `BlobNotFound`.
-
-1. **Read a byte range.** Useful when you only need part of the file — for example, the first ~16 KB of a Cloud Optimized GeoTIFF (the header). Most libraries (async-geotiff, GDAL, rasterio) only need the header to start working.
+1. **Read a byte range.** Useful when you only need part of the file. For example, the first ~16 KB of a Cloud Optimized GeoTIFF. 
 
    ```python
    import obstore
@@ -69,7 +65,7 @@ A note before you read: `from_asset()` scopes the store to that *specific blob* 
    )
    ```
 
-3. **Read the entire file.** Avoid this for large rasters — NAIP scenes can be 100–500 MB and Azure caps single-stream downloads at ~8–15 MB/s. Range reads and async (below) exist precisely to avoid this scenario.
+3. **Read the entire file.** Avoid this for large rasters. Range reads and async (below) exist to avoid this scenario.
 
    ```python
    buf = obstore.get(store, "").bytes()
@@ -77,7 +73,7 @@ A note before you read: `from_asset()` scopes the store to that *specific blob* 
 
 ## Run reads in parallel
 
-For multi-file workloads — building a mosaic, fetching all bands across all scenes in an AOI — running reads in parallel is dramatically faster than serial. obstore exposes async equivalents of every read function (`get_async`, `get_range_async`, etc.) that you can compose with `asyncio.gather`.
+For multi-file workloads like building a mosaic or fetching all bands across all scenes in an AOI, running reads in parallel is faster. obstore exposes async equivalents of every read function (`get_async`, `get_range_async`, etc.) that you can compose with `asyncio.gather`.
 
 Async needs its own credential provider class, `PlanetaryComputerAsyncCredentialProvider`, backed by `aiohttp` instead of `requests`. Same `from_asset()` signature.
 
@@ -94,11 +90,11 @@ async def fetch(start, end):
 results = await asyncio.gather(*[fetch(i * 4096, (i + 1) * 4096) for i in range(8)])
 ```
 
-The companion notebook benchmarks the speedup against serial reads — typically 3–5× faster in practice.
+This is typically 3–5× faster in practice.
 
 ## List objects across a container
 
-The asset-scoped pattern above is the right default, but it doesn't grant `List` permission on the container. To enumerate objects under a prefix ("show me every NAIP scene in Montana in 2023"), build a fresh provider against the container URL instead.
+To enumerate objects under a prefix ("show me every NAIP scene in Montana in 2023"), build a fresh provider against the container URL instead.
 
 ```python
 container_provider = PlanetaryComputerCredentialProvider(
@@ -117,7 +113,7 @@ for batch in obstore.list(container_store, prefix="v002/mt/2023/"):
 
 ## Hand the store to other libraries
 
-obstore really shines as a foundation. Any library that accepts an [obspec](https://github.com/developmentseed/obspec)-compatible store reads through your authenticated connection without re-doing auth. Open the same NAIP scene as a Cloud Optimized GeoTIFF using async-geotiff:
+Any library that accepts an [obspec](https://github.com/developmentseed/obspec)-compatible store reads through your authenticated connection without re-doing auth. Open the same NAIP scene as a Cloud Optimized GeoTIFF using async-geotiff:
 
 ```python
 from async_geotiff import GeoTIFF
@@ -157,7 +153,7 @@ obstore handles re-signing on expiry, talks to Azure's native blob API instead o
 
 ## Use the same code against other clouds
 
-obstore implements the [obspec](https://github.com/developmentseed/obspec) protocol, so the same read and write calls work against S3 or GCS — only the store constructor changes. Any library built on obspec inherits this portability automatically.
+obstore implements the [obspec](https://github.com/developmentseed/obspec) protocol, so the same read and write calls work against S3 or GCS. Any library built on obspec inherits this portability automatically.
 
 ```python
 from obstore.store import S3Store
@@ -166,5 +162,3 @@ s3_store = S3Store(bucket="my-bucket", region="us-west-2")
 buf = obstore.get(s3_store, "path/to/object").bytes()
 ```
 
-[nb-hub]: https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/microsoft/PlanetaryComputerExamples&urlpath=lab/tree/PlanetaryComputerExamples/quickstarts/obstore.ipynb&branch=main
-[nb-github]: https://github.com/microsoft/PlanetaryComputerExamples/blob/main/quickstarts/obstore.ipynb

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -122,7 +122,7 @@ geotiff = await GeoTIFF.open("", store=async_store)
 print(geotiff.transform, geotiff.crs.name)
 ```
 
-The same pattern works for [Lonboard](https://developmentseed.org/lonboard/) visualization and [zarr-python](https://zarr.dev/) datasets. See the [obstore Zarr example](https://developmentseed.org/obstore/latest/examples/zarr/) for a Planetary Computer Daymet walkthrough.
+[zarr-python](https://zarr.dev/) works through a thin adapter (`zarr.storage.ObjectStore` wraps your obstore store). See the [obstore Zarr example](https://developmentseed.org/obstore/latest/examples/zarr/) for a Planetary Computer Daymet walkthrough.
 
 ## Migrate from `planetary_computer.sign()` + fsspec
 

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -73,7 +73,7 @@ Once you have a working store, obstore exposes three read operations that map di
 
 ## Run reads in parallel
 
-For multi-file workloads like building a mosaic or fetching all bands across all scenes in an AOI, running reads in parallel is faster. obstore exposes async equivalents of every read function (`get_async`, `get_range_async`, etc.) that you can compose with `asyncio.gather`.
+For multi-file workloads like building a mosaic or fetching all bands across all scenes in an AOI, making concurrent requests is faster. obstore exposes async equivalents of every read function (`get_async`, `get_range_async`, etc.) that you can compose with `asyncio.gather`.
 
 Async needs its own credential provider class, `PlanetaryComputerAsyncCredentialProvider`, backed by `aiohttp` instead of `requests`. Same `from_asset()` signature.
 

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -2,7 +2,7 @@
 
 [obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. Using obstore, SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
 
-A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/microsoft/PlanetaryComputerExamples&urlpath=lab/tree/PlanetaryComputerExamples/quickstarts/obstore.ipynb&branch=main) · [View on GitHub](https://github.com/microsoft/PlanetaryComputerExamples/blob/main/quickstarts/obstore.ipynb)
+A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/microsoft/PlanetaryComputerExamples&urlpath=lab/tree/PlanetaryComputerExamples/quickstarts/obstore.ipynb&branch=main)
 
 ## Install obstore
 

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -1,0 +1,171 @@
+# Reading Planetary Computer data with obstore
+
+[obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. While much of the Planetary Computer ecosystem supports `planetary_computer.sign()` and fsspec, obstore offers a more modern path: SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
+
+A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub][nb-hub] · [Open in Colab][nb-colab] · [View on GitHub][nb-github]
+
+## Install obstore
+
+obstore works in any Python project — a script, a Jupyter notebook, a FastAPI backend, a Dagster or Airflow pipeline. To get started, install obstore alongside `pystac-client` (for searching the Planetary Computer's STAC API) and the HTTP libraries that power its credential providers:
+
+```bash
+uv add obstore pystac-client requests aiohttp aiohttp_retry
+```
+
+`requests` powers the sync credential provider; `aiohttp` and `aiohttp_retry` power the async one. Install both unless you know you only need one path. If you already have a project, you can substitute `pip install`, `poetry add`, or whatever your project uses.
+
+## Connect to a Planetary Computer asset
+
+The most common starting point is a STAC asset returned from a search. obstore's `PlanetaryComputerCredentialProvider` reads the asset's blob URL and handles SAS token acquisition and refresh for you.
+
+1. Open the Planetary Computer STAC catalog and pick a scene to work with.
+
+   ```python
+   import pystac_client
+   from obstore.auth.planetary_computer import PlanetaryComputerCredentialProvider
+
+   catalog = pystac_client.Client.open(
+       "https://planetarycomputer.microsoft.com/api/stac/v1"
+   )
+   item = next(catalog.search(collections=["naip"], max_items=1).items())
+   asset = item.assets["image"]
+   ```
+
+2. Build a credential provider from the asset.
+
+   ```python
+   provider = PlanetaryComputerCredentialProvider.from_asset(asset)
+   ```
+
+3. Build a store using that provider. The store is your reusable connection to that asset.
+
+   ```python
+   from obstore.store import AzureStore
+
+   store = AzureStore(credential_provider=provider)
+   ```
+
+That's the full setup. Every read, write, or library handoff below reuses the same `store`.
+
+## Read bytes from the store
+
+Once you have a working store, obstore exposes three read operations that map directly to native Azure Blob API calls.
+
+A note before you read: `from_asset()` scopes the store to that *specific blob* — the asset URL becomes the store's prefix. Reads use `""` as the path. Passing the asset href on top of the prefix would double it up and fail with `BlobNotFound`.
+
+1. **Read a byte range.** Useful when you only need part of the file — for example, the first ~16 KB of a Cloud Optimized GeoTIFF (the header). Most libraries (async-geotiff, GDAL, rasterio) only need the header to start working.
+
+   ```python
+   import obstore
+
+   header = obstore.get_range(store, "", start=0, end=16384)
+   ```
+
+2. **Read multiple byte ranges in a single request.** Cuts round-trip latency when you need several non-contiguous slices of the same file (e.g. multiple COG tiles).
+
+   ```python
+   ranges = obstore.get_ranges(
+       store, "", starts=[0, 65536], ends=[16384, 81920]
+   )
+   ```
+
+3. **Read the entire file.** Avoid this for large rasters — NAIP scenes can be 100–500 MB and Azure caps single-stream downloads at ~8–15 MB/s. Range reads and async (below) exist precisely to avoid this scenario.
+
+   ```python
+   buf = obstore.get(store, "").bytes()
+   ```
+
+## Run reads in parallel
+
+For multi-file workloads — building a mosaic, fetching all bands across all scenes in an AOI — running reads in parallel is dramatically faster than serial. obstore exposes async equivalents of every read function (`get_async`, `get_range_async`, etc.) that you can compose with `asyncio.gather`.
+
+Async needs its own credential provider class, `PlanetaryComputerAsyncCredentialProvider`, backed by `aiohttp` instead of `requests`. Same `from_asset()` signature.
+
+```python
+import asyncio
+from obstore.auth.planetary_computer import PlanetaryComputerAsyncCredentialProvider
+
+async_provider = PlanetaryComputerAsyncCredentialProvider.from_asset(asset)
+async_store = AzureStore(credential_provider=async_provider)
+
+async def fetch(start, end):
+    return await obstore.get_range_async(async_store, "", start=start, end=end)
+
+results = await asyncio.gather(*[fetch(i * 4096, (i + 1) * 4096) for i in range(8)])
+```
+
+The companion notebook benchmarks the speedup against serial reads — typically 3–5× faster in practice.
+
+## List objects across a container
+
+The asset-scoped pattern above is the right default, but it doesn't grant `List` permission on the container. To enumerate objects under a prefix ("show me every NAIP scene in Montana in 2023"), build a fresh provider against the container URL instead.
+
+```python
+container_provider = PlanetaryComputerCredentialProvider(
+    "https://naipeuwest.blob.core.windows.net/naip/"
+)
+container_store = AzureStore(
+    account_name="naipeuwest",
+    container_name="naip",
+    credential_provider=container_provider,
+)
+
+for batch in obstore.list(container_store, prefix="v002/mt/2023/"):
+    for entry in batch:
+        print(entry["path"], entry["size"])
+```
+
+## Hand the store to other libraries
+
+obstore really shines as a foundation. Any library that accepts an [obspec](https://github.com/developmentseed/obspec)-compatible store reads through your authenticated connection without re-doing auth. Open the same NAIP scene as a Cloud Optimized GeoTIFF using async-geotiff:
+
+```python
+from async_geotiff import GeoTIFF
+
+geotiff = await GeoTIFF.open("", store=async_store)
+print(geotiff.transform, geotiff.crs.name)
+```
+
+The same pattern works for [Lonboard](https://developmentseed.org/lonboard/) visualization and [zarr-python](https://zarr.dev/) datasets. See the [obstore Zarr example](https://developmentseed.org/obstore/latest/examples/zarr/) for a Planetary Computer Daymet walkthrough.
+
+## Migrate from `planetary_computer.sign()` + fsspec
+
+If you're updating an existing project, here's the side-by-side. The old pattern:
+
+```python
+import planetary_computer
+import fsspec
+
+signed = planetary_computer.sign(asset.href)
+with fsspec.open(signed) as f:
+    data = f.read()
+```
+
+The obstore equivalent:
+
+```python
+from obstore.auth.planetary_computer import PlanetaryComputerCredentialProvider
+from obstore.store import AzureStore
+import obstore
+
+provider = PlanetaryComputerCredentialProvider.from_asset(asset)
+store = AzureStore(credential_provider=provider)
+data = obstore.get(store, "").bytes()
+```
+
+obstore handles re-signing on expiry, talks to Azure's native blob API instead of routing through HTTP via fsspec, and exposes async I/O for parallel reads — all without changing your auth code per request.
+
+## Use the same code against other clouds
+
+obstore implements the [obspec](https://github.com/developmentseed/obspec) protocol, so the same read and write calls work against S3 or GCS — only the store constructor changes. Any library built on obspec inherits this portability automatically.
+
+```python
+from obstore.store import S3Store
+
+s3_store = S3Store(bucket="my-bucket", region="us-west-2")
+buf = obstore.get(s3_store, "path/to/object").bytes()
+```
+
+[nb-hub]: # "TODO: link to notebook on Planetary Computer Hub"
+[nb-colab]: # "TODO: link to notebook on Colab"
+[nb-github]: # "TODO: link to notebook in companion repo"

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -113,7 +113,7 @@ for batch in obstore.list(container_store, prefix="v002/mt/2023/"):
 
 ## Hand the store to other libraries
 
-Any library that accepts an [obspec](https://github.com/developmentseed/obspec)-compatible store reads through your authenticated connection without re-doing auth. Open the same NAIP scene as a Cloud Optimized GeoTIFF using async-geotiff:
+Any library that accepts an [obspec](https://github.com/developmentseed/obspec)-compatible store reads through your authenticated connection without re-doing auth. Open the same NAIP scene as a Cloud Optimized GeoTIFF using [async-geotiff](https://github.com/developmentseed/async-geotiff):
 
 ```python
 from async_geotiff import GeoTIFF

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -1,6 +1,6 @@
 # Reading Planetary Computer data with obstore
 
-[obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. Using obstore, SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
+[obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. Using obstore, Planetary Computer SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
 
 A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/microsoft/PlanetaryComputerExamples&urlpath=lab/tree/PlanetaryComputerExamples/quickstarts/obstore.ipynb&branch=main)
 

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -2,7 +2,7 @@
 
 [obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. While much of the Planetary Computer ecosystem supports `planetary_computer.sign()` and fsspec, obstore offers a more modern path: SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
 
-A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub][nb-hub] · [Open in Colab][nb-colab] · [View on GitHub][nb-github]
+A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub][nb-hub] · [View on GitHub][nb-github]
 
 ## Install obstore
 
@@ -166,6 +166,5 @@ s3_store = S3Store(bucket="my-bucket", region="us-west-2")
 buf = obstore.get(s3_store, "path/to/object").bytes()
 ```
 
-[nb-hub]: # "TODO: link to notebook on Planetary Computer Hub"
-[nb-colab]: # "TODO: link to notebook on Colab"
-[nb-github]: # "TODO: link to notebook in companion repo"
+[nb-hub]: https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/microsoft/PlanetaryComputerExamples&urlpath=lab/tree/PlanetaryComputerExamples/quickstarts/obstore.ipynb&branch=main
+[nb-github]: https://github.com/microsoft/PlanetaryComputerExamples/blob/main/quickstarts/obstore.ipynb

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -6,7 +6,7 @@ A companion notebook walks through every step end-to-end with live timings. [Ope
 
 ## Install obstore
 
-obstore works in any Python project. To get started, install obstore alongside `pystac-client` (for searching the Planetary Computer's STAC API) and the HTTP libraries that power its credential providers:
+obstore works in any Python project. To get started, install obstore alongside `pystac-client` (for searching the Planetary Computer's STAC API) and the HTTP libraries that power its [credential providers](https://developmentseed.org/obstore/latest/authentication/#credential-providers):
 
 ```bash
 uv add obstore pystac-client requests aiohttp aiohttp_retry

--- a/docs/overview/obstore.md
+++ b/docs/overview/obstore.md
@@ -1,6 +1,6 @@
 # Reading Planetary Computer data with obstore
 
-[obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores (Azure Blob, Amazon S3, Google Cloud Storage) directly through their native APIs. Using obstore, SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
+[obstore](https://developmentseed.org/obstore/) is a Python library for reading and writing cloud object stores through a single, unified API that works the same across Azure Blob, Amazon S3, and Google Cloud Storage. Using obstore, SAS tokens refresh automatically, async I/O is built in, and the same store you build for reading bytes can be handed to higher-level libraries like [async-geotiff](https://github.com/developmentseed/async-geotiff), [Lonboard](https://developmentseed.org/lonboard/), and [zarr-python](https://zarr.dev/) without re-authenticating.
 
 A companion notebook walks through every step end-to-end with live timings. [Open in Planetary Computer Hub](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/microsoft/PlanetaryComputerExamples&urlpath=lab/tree/PlanetaryComputerExamples/quickstarts/obstore.ipynb&branch=main)
 
@@ -37,7 +37,7 @@ The most common starting point is a STAC asset returned from a search. obstore's
    provider = PlanetaryComputerCredentialProvider.from_asset(asset)
    ```
 
-3. Build a store using that provider. The store is your reusable connection to that asset.
+3. Build a store using that provider.
 
    ```python
    from obstore.store import AzureStore
@@ -45,68 +45,85 @@ The most common starting point is a STAC asset returned from a search. obstore's
    store = AzureStore(credential_provider=provider)
    ```
 
+   The credentials obstore fetches grant read access to the *entire container*, not just this one file. `from_asset` simply points the store's prefix at the asset's blob path — which is why the reads below pass an empty path (`""`). To read across the container, see [Open the whole container](#open-the-whole-container) below.
+
 ## Read bytes from the store
 
-Once you have a working store, obstore exposes three read operations that map directly to native Azure Blob API calls.
+Once you have a working store, obstore exposes three read methods. Call them directly on the store.
 
-1. **Read a byte range.** Useful when you only need part of the file. For example, the first ~16 KB of a Cloud Optimized GeoTIFF. 
-
-   ```python
-   import obstore
-
-   header = obstore.get_range(store, "", start=0, end=16384)
-   ```
-
-2. **Read multiple byte ranges in a single request.** Cuts round-trip latency when you need several non-contiguous slices of the same file (e.g. multiple COG tiles).
+1. **Read a byte range.** Useful when you only need part of the file. For example, the first ~16 KB of a Cloud Optimized GeoTIFF.
 
    ```python
-   ranges = obstore.get_ranges(
-       store, "", starts=[0, 65536], ends=[16384, 81920]
-   )
+   header = store.get_range("", start=0, end=16384)
    ```
 
-3. **Read the entire file.** Avoid this for large rasters. Range reads and async (below) exist to avoid this scenario.
+2. **Read multiple byte ranges in a single request.** Cuts round-trip latency when you need several non-contiguous slices of the same file (e.g. multiple COG tiles). obstore coalesces adjacent ranges into a single network request for you.
 
    ```python
-   buf = obstore.get(store, "").bytes()
+   ranges = store.get_ranges("", starts=[0, 65536], ends=[16384, 81920])
    ```
+
+3. **Read the entire file.** `store.get` returns a result you can iterate to stream the body in chunks; call `.bytes()` to collect it into one buffer. Avoid collecting large rasters — range reads and async (below) exist for that.
+
+   ```python
+   buf = store.get("").bytes()
+   ```
+
+## Open the whole container
+
+`from_asset` is the quickest path for a single scene. When you want to read or list many objects, build the store against the container root instead, then pass full blob paths.
+
+```python
+container_store = AzureStore(
+    account_name="naipeuwest",
+    container_name="naip",
+    credential_provider=PlanetaryComputerCredentialProvider(
+        "https://naipeuwest.blob.core.windows.net/naip/"
+    ),
+)
+
+buf = container_store.get("v002/mt/2023/40086/m_4008601_se_12_060_20230621.tif").bytes()
+```
 
 ## Run reads in parallel
 
-For multi-file workloads like building a mosaic or fetching all bands across all scenes in an AOI, running reads in parallel is faster. obstore exposes async equivalents of every read function (`get_async`, `get_range_async`, etc.) that you can compose with `asyncio.gather`.
+For multi-file workloads — building a mosaic, or fetching every band across every scene in an AOI — running reads concurrently is much faster than one at a time. obstore exposes async equivalents of every read method (`get_async`, `get_range_async`, `get_ranges_async`), which you compose with `asyncio.gather`.
 
-Async needs its own credential provider class, `PlanetaryComputerAsyncCredentialProvider`, backed by `aiohttp` instead of `requests`. Same `from_asset()` signature.
+Async needs its own credential provider, `PlanetaryComputerAsyncCredentialProvider`, backed by `aiohttp` instead of `requests`. It takes the same `from_asset()` constructor.
 
 ```python
 import asyncio
 from obstore.auth.planetary_computer import PlanetaryComputerAsyncCredentialProvider
 
-async_provider = PlanetaryComputerAsyncCredentialProvider.from_asset(asset)
-async_store = AzureStore(credential_provider=async_provider)
+items = list(catalog.search(collections=["naip"], max_items=8).items())
+stores = [
+    AzureStore(
+        credential_provider=PlanetaryComputerAsyncCredentialProvider.from_asset(
+            item.assets["image"]
+        )
+    )
+    for item in items
+]
 
-async def fetch(start, end):
-    return await obstore.get_range_async(async_store, "", start=start, end=end)
-
-results = await asyncio.gather(*[fetch(i * 4096, (i + 1) * 4096) for i in range(8)])
+headers = await asyncio.gather(
+    *[store.get_range_async("", start=0, end=16384) for store in stores]
+)
 ```
 
-This is typically 3–5× faster in practice.
+To read many ranges *within a single file*, don't fan out one request per range. Use `get_ranges_async`, which coalesces adjacent ranges into a single network request under the hood:
+
+```python
+tiles = await stores[0].get_ranges_async(
+    "", starts=[0, 65536, 131072], ends=[65536, 131072, 196608]
+)
+```
 
 ## List objects across a container
 
-To enumerate objects under a prefix ("show me every NAIP scene in Montana in 2023"), build a fresh provider against the container URL instead.
+To enumerate objects under a prefix ("show me every NAIP scene in Montana in 2023"), call `list` on the `container_store` from above.
 
 ```python
-container_provider = PlanetaryComputerCredentialProvider(
-    "https://naipeuwest.blob.core.windows.net/naip/"
-)
-container_store = AzureStore(
-    account_name="naipeuwest",
-    container_name="naip",
-    credential_provider=container_provider,
-)
-
-for batch in obstore.list(container_store, prefix="v002/mt/2023/"):
+for batch in container_store.list(prefix="v002/mt/2023/"):
     for entry in batch:
         print(entry["path"], entry["size"])
 ```
@@ -118,6 +135,9 @@ Any library that accepts an [obspec](https://github.com/developmentseed/obspec)-
 ```python
 from async_geotiff import GeoTIFF
 
+async_store = AzureStore(
+    credential_provider=PlanetaryComputerAsyncCredentialProvider.from_asset(asset)
+)
 geotiff = await GeoTIFF.open("", store=async_store)
 print(geotiff.transform, geotiff.crs.name)
 ```
@@ -142,14 +162,13 @@ The obstore equivalent:
 ```python
 from obstore.auth.planetary_computer import PlanetaryComputerCredentialProvider
 from obstore.store import AzureStore
-import obstore
 
 provider = PlanetaryComputerCredentialProvider.from_asset(asset)
 store = AzureStore(credential_provider=provider)
-data = obstore.get(store, "").bytes()
+data = store.get("").bytes()
 ```
 
-obstore handles re-signing on expiry, talks to Azure's native blob API instead of routing through HTTP via fsspec, and exposes async I/O for parallel reads — all without changing your auth code per request.
+obstore handles re-signing on expiry, talks to Azure Blob Storage directly instead of routing through HTTP via fsspec, and exposes async I/O for parallel reads — all without changing your auth code per request.
 
 ## Use the same code against other clouds
 
@@ -159,6 +178,6 @@ obstore implements the [obspec](https://github.com/developmentseed/obspec) proto
 from obstore.store import S3Store
 
 s3_store = S3Store(bucket="my-bucket", region="us-west-2")
-buf = obstore.get(s3_store, "path/to/object").bytes()
+buf = s3_store.get("path/to/object").bytes()
 ```
 

--- a/etl/config/external_docs_config.yml
+++ b/etl/config/external_docs_config.yml
@@ -28,3 +28,4 @@
 - file_url: quickstarts/reading-tabular-data.ipynb
 - file_url: quickstarts/reading-zarr-data.ipynb
 - file_url: quickstarts/storage.ipynb
+- file_url: quickstarts/obstore.ipynb


### PR DESCRIPTION
Tutorial for obstore, based on the outline here: https://docs.google.com/document/d/1LIf6SvMHK3Gr8gSG8eqmjwyROeeoQl3Odg1CVLqp1AI/edit?usp=sharing

Related notebook: https://github.com/microsoft/PlanetaryComputerExamples/pull/313

