### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
+++ b/.github/workflows/azure-static-web-apps-icy-meadow-0fc35e30f.yml
@@ -27,10 +27,10 @@ jobs:
       REACT_APP_HUB_URL: ${{ secrets.HUB_URL }}
       REACT_APP_AZMAPS_KEY: ${{ secrets.AZMAPS_KEY }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         id: npm-cache
         with:
           path: ~/.npm
@@ -49,7 +49,7 @@ jobs:
         run: ./scripts/cibuild
       - name: Deploy (Staging)
         id: builddeploy-staging
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_MEADOW_0FC35E30F }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Close Pull Request (Staging)
         id: closepullrequest-staging
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_MEADOW_0FC35E30F }}

--- a/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-sand-0ed34c70f.yml
@@ -27,7 +27,7 @@ jobs:
       REACT_APP_HUB_URL: ${{ secrets.HUB_URL }}
       REACT_APP_AZMAPS_KEY: ${{ secrets.AZMAPS_KEY }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
       - name: Build docs and metadata
@@ -39,7 +39,7 @@ jobs:
         run: ./scripts/cibuild
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_SAND_0ED34C70F  }}
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_SAND_0ED34C70F  }}

--- a/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-stone-06c70c70f.yml
@@ -27,10 +27,10 @@ jobs:
       REACT_APP_HUB_URL: ${{ secrets.HUB_URL }}
       REACT_APP_AZMAPS_KEY: ${{ secrets.AZMAPS_KEY }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         id: npm-cache
         with:
           path: ~/.npm
@@ -49,7 +49,7 @@ jobs:
         run: ./scripts/cibuild
       - name: Build And Deploy (Test)
         id: builddeploy-test
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_WONDERFUL_STONE_06c70c70f }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_WONDERFUL_STONE_06c70c70f }}

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v5.1.0
+        uses: github/combine-prs@20d70f9d80eeb5958667d0602da433bd04ca6713 # v5.1.0
         with:
           labels: combined-pr

--- a/.github/workflows/cypress-ci.yml
+++ b/.github/workflows/cypress-ci.yml
@@ -15,24 +15,24 @@ jobs:
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@d79d2d530a66e641eb4a5f227e13bc985c60b964 # v4.2.2
         with:
           install-command: npm install
           start: npm start
           wait-on: http://localhost:3000
           wait-on-timeout: 95
           browser: chrome
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: cypress-videos


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). This groups Dependabot PRs for GitHub Actions and enforces a minimum 7-day cooldown between updates. If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
